### PR TITLE
core, bridge(c,cpp,np), cpu/cape: Added BH_TALLY instruction.

### DIFF
--- a/bridge/c/codegen/templates/implementation_basics.ctpl
+++ b/bridge/c/codegen/templates/implementation_basics.ctpl
@@ -24,6 +24,12 @@ void bh_runtime_shutdown(void){
    //delete &Runtime::instance();
 }
 
+// Send the tally instruction
+void bh_runtime_tally(void)
+{
+    bh_tally();
+}
+
 %for $ctype, $bh_atype, $bh_ctype, $bh_enum in $ops
 
 // $bh_enum

--- a/bridge/c/codegen/templates/type_header.ctpl
+++ b/bridge/c/codegen/templates/type_header.ctpl
@@ -26,6 +26,9 @@ DLLEXPORT void bh_runtime_flush(void);
 // Shutdown Bohrium
 DLLEXPORT void bh_runtime_shutdown(void);
 
+// Send the BH_TALLY instruction.
+DLLEXPORT void bh_runtime_tally(void);
+
 // Common type forward definition
 #ifndef __BH_ARRAY_H
 struct bh_base;

--- a/bridge/cpp/bxx/bohrium.hpp
+++ b/bridge/cpp/bxx/bohrium.hpp
@@ -345,6 +345,8 @@ public:
     template <typename TO>
     void enqueue(bh_opcode opcode, multi_array<TO>& op0);
 
+    void enqueue(bh_opcode opcode);
+
     template <typename TO>
     void enqueue(bh_opcode opcode, multi_array<TO>& op0, const uint64_t op1, const uint64_t op2);
 

--- a/bridge/cpp/bxx/runtime.hpp
+++ b/bridge/cpp/bxx/runtime.hpp
@@ -322,6 +322,23 @@ void Runtime::enqueue(bh_opcode opcode, multi_array<TO>& op0)
 }
 
 //
+// This function is used to encode SYSTEM opcodes without operands (NONE and TALLY)
+//
+inline
+void Runtime::enqueue(bh_opcode opcode)
+{
+    bh_instruction* instr;
+
+    guard();
+
+    instr = &queue[queue_size++];
+    instr->opcode = opcode;
+    instr->operand[0].base = NULL;
+    instr->operand[1].base = NULL;
+    instr->operand[2].base = NULL;
+}
+
+//
 //  This function should only be used by random to encode the degenerate bh_r123 type.
 //
 template <typename TO>

--- a/bridge/cpp/bxx/runtime.operations.hpp
+++ b/bridge/cpp/bxx/runtime.operations.hpp
@@ -32,6 +32,22 @@ namespace bxx {
 
 
 
+inline
+void bh_none (void)
+{
+    Runtime::instance().enqueue((bh_opcode)BH_NONE);
+}
+
+
+inline
+void bh_tally (void)
+{
+    Runtime::instance().enqueue((bh_opcode)BH_TALLY);
+}
+
+
+
+
 //
 // bh_add - BH_ADD - runtime.binary - 3
 //

--- a/bridge/cpp/codegen/gen.py
+++ b/bridge/cpp/codegen/gen.py
@@ -142,6 +142,7 @@ def main():
         ('runtime.typechecker.ctpl', 'runtime.typechecker.hpp', checker),
 
         ('runtime.header.ctpl',     'runtime.operations.hpp', datasets['runtime.binary']),
+        ('runtime.none.ctpl',       'runtime.operations.hpp', datasets['runtime.none']),
         ('runtime.binary.ctpl',     'runtime.operations.hpp', datasets['runtime.binary']),
         ('runtime.binary.bool.ctpl','runtime.operations.hpp', datasets['runtime.binary.bool']),
         ('runtime.unary.ctpl',      'runtime.operations.hpp', datasets['runtime.unary']),

--- a/bridge/cpp/codegen/operators.json
+++ b/bridge/cpp/codegen/operators.json
@@ -230,6 +230,8 @@
 ["matmul",      "BH_MATMUL",    "sugar.binary",   true],
 ["bh_matmul",   "BH_MATMUL",    "runtime.binary", true],
 
+["bh_none",     "BH_NONE",      "runtime.none", true],
+["bh_tally",    "BH_TALLY",     "runtime.none", true],
 ["bh_free",     "BH_FREE",      "runtime.zero", true],
 ["bh_sync",     "BH_SYNC",      "runtime.zero", true],
 ["bh_discard",  "BH_DISCARD",   "runtime.zero", true]

--- a/bridge/cpp/codegen/templates/runtime.none.ctpl
+++ b/bridge/cpp/codegen/templates/runtime.none.ctpl
@@ -1,0 +1,16 @@
+#slurp
+#compiler-settings
+directiveStartToken = %
+#end compiler-settings
+%slurp
+
+%for $op, $opcode, $optype, $opcount, $typesigs, $layouts, $broadcast in $data
+
+inline
+void $op (void)
+{
+    Runtime::instance().enqueue((bh_opcode)$opcode);
+}
+
+%end for
+

--- a/bridge/npbackend/target/__init__.py
+++ b/bridge/npbackend/target/__init__.py
@@ -43,6 +43,9 @@ if TARGET not in TARGETS:   # Validate the target
     )
     raise RuntimeError(msg)
 
+if TARGET == "bhc":
+    METHODS.append("tally")
+
 # Do the actual import of methods from the chosen target
 exec("from .target_%s import %s" % (TARGET, ", ".join(METHODS)))
 

--- a/bridge/npbackend/target/target_bhc.py
+++ b/bridge/npbackend/target/target_bhc.py
@@ -225,4 +225,6 @@ def random123(size, start_index, key):
     base = Base(size, dtype, bhc_obj)
     return View(1, 0, (size,), (dtype.itemsize,), base)
 
-
+def tally():
+    bhc.bh_runtime_tally()
+    return None

--- a/core/bh_ir.cpp
+++ b/core/bh_ir.cpp
@@ -155,6 +155,7 @@ void bh_ir_kernel::add_instr(uint64_t instr_idx)
     const bh_instruction& instr = bhir->instr_list[instr_idx];
     switch (instr.opcode) {
     case BH_NONE:
+    case BH_TALLY:
         break;
     case BH_SYNC:
         syncs.insert(instr.operand[0].base);

--- a/core/codegen/opcodes.json
+++ b/core/codegen/opcodes.json
@@ -1504,6 +1504,22 @@
     "system_opcode": true
 },
 {
+    "opcode": "BH_TALLY",
+    "doc":  "System instruction that informs the child component to tally operations.",
+    "code": "TALLY",
+    "id":   "58",
+    "nop":   0,
+    "types": [
+    ],
+    "layout": [
+    ],
+    "elementwise":   false,
+    "composite":     false,
+    "reduction":     false,
+    "accumulate":    false,
+    "system_opcode": true
+},
+{
     "opcode": "BH_ADD_REDUCE",
     "doc":  "Sums all elements in the specified dimension.",
     "code": "sum(a, axis)",

--- a/test/python/test_bohrium.py
+++ b/test/python/test_bohrium.py
@@ -10,11 +10,10 @@ class test_bohrium(numpytest):
             exec(v)
             yield (a,v)
 
-    def test_tally(self,a):
-        cmd = "\n".join([
-            "res = a[0] + a[0]",
-            'if "target" in np.__dict__ and "tally" in np.target.__dict__:',
-            "    np.target.tally()"
-        ])
+    def test_tally(self, a):
+        cmd = "res = a[0] + a[0]"
         exec(cmd)
+        if bh.check(a[0]):
+            bh.target.tally()
         return (res,cmd)
+

--- a/test/python/test_bohrium.py
+++ b/test/python/test_bohrium.py
@@ -1,0 +1,20 @@
+import numpy as np
+import bohrium as bh
+from numpytest import numpytest,gen_views,TYPES
+
+class test_bohrium(numpytest):
+
+    def init(self):
+        for v in gen_views(1,2):
+            a = {}
+            exec(v)
+            yield (a,v)
+
+    def test_tally(self,a):
+        cmd = "\n".join([
+            "res = a[0] + a[0]",
+            'if "target" in np.__dict__ and "tally" in np.target.__dict__:',
+            "    np.target.tally()"
+        ])
+        exec(cmd)
+        return (res,cmd)

--- a/ve/cpu/autogen/tac/operations.json
+++ b/ve/cpu/autogen/tac/operations.json
@@ -157,7 +157,8 @@
     "operators": [
         "KP_FREE",
         "KP_DISCARD",
-        "KP_SYNC"
+        "KP_SYNC",
+        "KP_TALLY"
     ]
 },
 

--- a/ve/cpu/autogen/tac/operators.json
+++ b/ve/cpu/autogen/tac/operators.json
@@ -63,11 +63,12 @@
     {"id": 60, "name": "KP_DISCARD",   "nop": 1, "types": []},
     {"id": 61, "name": "KP_FREE",      "nop": 1, "types": []},
     {"id": 62, "name": "KP_SYNC",      "nop": 1, "types": []},
-    {"id": 63, "name": "KP_NONE",      "nop": 0, "types": []},
+    {"id": 63, "name": "KP_TALLY",     "nop": 0, "types": []},
+    {"id": 64, "name": "KP_NONE",      "nop": 0, "types": []},
 
-    {"id": 64, "name": "KP_FLOOD",     "nop": 1, "types": []},
-    {"id": 65, "name": "KP_RANDOM",    "nop": 2, "types": []},
-    {"id": 66, "name": "KP_RANGE",     "nop": 0, "types": []},
+    {"id": 65, "name": "KP_FLOOD",     "nop": 1, "types": []},
+    {"id": 66, "name": "KP_RANDOM",    "nop": 2, "types": []},
+    {"id": 67, "name": "KP_RANGE",     "nop": 0, "types": []},
 
-    {"id": 67, "name": "KP_EXTENSION_OPERATOR","nop": 0, "types": []}
+    {"id": 68, "name": "KP_EXTENSION_OPERATOR","nop": 0, "types": []}
 ]

--- a/ve/cpu/autogen/templates/instrs_to_tacs.tpl
+++ b/ve/cpu/autogen/templates/instrs_to_tacs.tpl
@@ -24,8 +24,8 @@ void instrs_to_tacs(bh_ir& bhir, Program& tacs, SymbolTable& symbol_table)
 
         //
         // Program packing: output argument
-        // NOTE: All but BH_NONE has an output which is an array
-        if (instr.opcode != BH_NONE) {
+        // NOTE: All but BH_NONE and TALLY has an output array
+        if ((instr.opcode != BH_NONE) && (instr.opcode != BH_TALLY)) {
             out = symbol_table.map_operand(instr, 0);
         }
 

--- a/ve/cpu/kp_utils.c
+++ b/ve/cpu/kp_utils.c
@@ -65,6 +65,7 @@ size_t kp_tac_noperands(const kp_tac* tac)
                 case KP_SYNC:
                     return 1;
                 case KP_NONE:
+                case KP_TALLY:
                     return 0;
                 default:
                     fprintf(stderr, "kp_tac_noperands: Unknown #operands of KP_SYSTEM, assuming 0;\n");

--- a/ve/cpu/tools/Makefile
+++ b/ve/cpu/tools/Makefile
@@ -4,7 +4,7 @@ BDIR=/tmp/bhbuild_cpu/
 #PAR_LVL=-j$(shell expr $(shell nproc) / 2)
 PAR_LVL=-j1
 BH_PYTHON=python
-TEST_EXCLUDE=
+TEST_EXCLUDE=--exclude-test=test_lbm_3d
 DUMPSRC=1
 
 BUILD_OPTIONS=


### PR DESCRIPTION
Accessible in BXX via bh_tally().
Accessible in C-brdige via bh_runtime_tally()
Accessible in Python bridge via [import-name].target.tally()

On the CPU the tally instruction is a NOOP.
Which currently is implemented by ignoring it in system instruction processing.