### PR TITLE
Remove meaningless opcodes

### DIFF
--- a/core/codegen/opcodes.json
+++ b/core/codegen/opcodes.json
@@ -38,7 +38,6 @@
     "id":   "2",
     "nop":   3,
     "types": [
-            [ "BH_BOOL", "BH_BOOL", "BH_BOOL" ],
             [ "BH_COMPLEX128", "BH_COMPLEX128", "BH_COMPLEX128" ],
             [ "BH_COMPLEX64", "BH_COMPLEX64", "BH_COMPLEX64" ],
             [ "BH_FLOAT32", "BH_FLOAT32", "BH_FLOAT32" ],


### PR DESCRIPTION
Subtraction of boolean types seems pointless.

The `numpytest.py` test fails at the moment, because it tries to use an obsoleted subtraction on boolean types.