### PR TITLE
Remove commented out unit test cases

### DIFF
--- a/bridge/npbackend/array_create.py
+++ b/bridge/npbackend/array_create.py
@@ -763,29 +763,3 @@ def save(file, arr):
     numpy.save(file, arr)
     if bohrium:
         array(arr, bohrium=True)
-
-"""
-Since ufunc.py uses relative imports then these tests cannot be executed, I
-assume that they are deprecated code and haven't been used for anything in
-several years? This this "UNIT TEST" cover anything that numpytest does not?
-Does it every run?
-
-###############################################################################
-################################ UNIT TEST ####################################
-###############################################################################
-
-import unittest
-from . import _info
-
-class Tests(unittest.TestCase):
-
-    def test_empty_dtypes(self):
-        for t in _info.numpy_types:
-            a = empty((4, 4), dtype=t)
-
-
-if __name__ == '__main__':
-    suite = unittest.TestLoader().loadTestsFromTestCase(Tests)
-    unittest.TextTestRunner(verbosity=2).run(suite)
-
-"""

--- a/bridge/npbackend/array_manipulation.py
+++ b/bridge/npbackend/array_manipulation.py
@@ -354,5 +354,3 @@ def broadcast_arrays(*args):
         else:
             ret.append(b)
     return ret
-
-

--- a/bridge/npbackend/ufunc.py
+++ b/bridge/npbackend/ufunc.py
@@ -499,5 +499,5 @@ for op in _info.op.itervalues():
 
 for ufunc in UFUNCS:                        # Expose via their name.
     exec("%s = ufunc" % ufunc.info['name'])
-del(ufunc) # We do not want to expose a function named "ufunc"
 
+del ufunc # We do not want to expose a function named "ufunc"


### PR DESCRIPTION
They haven't really been run for over a year now, since they have been commented out.