### PR TITLE
Re-enable Jacobi module test

### DIFF
--- a/test/python/test_benchmarks.py
+++ b/test/python/test_benchmarks.py
@@ -407,14 +407,12 @@ class test_wireworld(BenchHelper, numpytest):
 #
 #   Testing via import of modules
 #
-class test_jacobi_module(numpytest):#disabled
+class test_jacobi_module(numpytest):
     def __init__(self):
         numpytest.__init__(self)
         self.config['maxerror'] = 0.00001
         self.size = 20
     def init(self):
-        print("We need to implement numpy.norm() for test_jacobi() to work")
-        raise StopIteration()
         for t in ['bh.float32','bh.float64']:
             a = {}
             cmd  = "a[0] = self.array(({0},{0}),dtype={1});".format(self.size,t)


### PR DESCRIPTION
@safl already implemented `norm` in f2f37741edcc4e03d2d0020814c32809e9ddbeaa, so I'll just re-enable the Jacobi test again.