### PR TITLE
Actually increase pc and end pointers when expanding powk/matmul

### DIFF
--- a/filter/bcexp/expander.cpp
+++ b/filter/bcexp/expander.cpp
@@ -40,20 +40,20 @@ void Expander::expand(bh_ir& bhir)
 
         case BH_POWER:
             if (powk_) {
-                end += expand_powk(bhir, pc);
+                increase = expand_powk(bhir, pc);
                 end += increase;
                 pc += increase;
             }
             break;
-            
+
         case BH_MATMUL:
             if (matmul_) {
-                end += expand_matmul(bhir, pc);
+                increase = expand_matmul(bhir, pc);
                 end += increase;
                 pc += increase;
             }
             break;
-            
+
         case BH_SIGN:
             if (sign_) {
                 increase = expand_sign(bhir, pc);
@@ -61,6 +61,7 @@ void Expander::expand(bh_ir& bhir)
                 pc += increase;
             }
             break;
+
         case BH_ADD_REDUCE:
         case BH_MULTIPLY_REDUCE:
         case BH_MINIMUM_REDUCE:
@@ -110,7 +111,7 @@ bh_base* Expander::make_base(bh_type type, bh_index nelem)
         fprintf(stderr, "Expander::make_base(...) bh_base allocation failed.\n");
         throw std::runtime_error("Expander::make_base(...) bh_base allocation failed.\n");
     }
-    
+
     base->type = type;
     base->nelem = nelem;
     base->data = NULL;
@@ -163,4 +164,3 @@ Expander::~Expander(void)
 }
 
 }}}
-


### PR DESCRIPTION
In both cases, we only increase the end pointer, but not the current instruction pointer, which means that we'll look at the same instructions, that we have just created.

Either the solution is like written in this PR or instead one could just not add the 0 to the pointers. It might be valid to look at the same instructions again, another expander might actually match the current instruction and thus rework it even further.