### PR TITLE
Collect filter

### DIFF
--- a/config.ini.in
+++ b/config.ini.in
@@ -213,6 +213,7 @@ type = filter
 impl = ${CMAKE_INSTALL_PREFIX}/lib/libbh_filter_bccon${CMAKE_SHARED_LIBRARY_SUFFIX}
 children = node
 reduction = 1
+collect = 1
 timing = false
 
 [noneremover]

--- a/core/bh_component.cpp
+++ b/core/bh_component.cpp
@@ -563,7 +563,7 @@ char* bh_component_config_lookup(const bh_component *component, const char* key)
 }
 
 /*
- * @brief     Lookup a keys value in the config fil converted to a bool
+ * @brief     Lookup a keys value in the config file converted to a bool
  * @component The component.
  * @key       The key to lookup in the config file
  * @notfound  Value to return in case of error
@@ -572,19 +572,29 @@ char* bh_component_config_lookup(const bh_component *component, const char* key)
 bool bh_component_config_lookup_bool(const bh_component *component,
                                      const char* key, bool notfound)
 {
-    char* val ;
-    bool ret ;
-    val = bh_component_config_lookup(component, key);
+    char* val = bh_component_config_lookup(component, key);
+
     if (val == NULL)
-        return notfound ;
-    if (val[0]=='y' || val[0]=='Y' || val[0]=='1' || val[0]=='t' || val[0]=='T') {
-        ret = true;
-    } else if (val[0]=='n' || val[0]=='N' || val[0]=='0' || val[0]=='f' || val[0]=='F') {
-        ret = false;
-    } else {
-        ret = notfound ;
+        return notfound;
+
+    switch(val[0]) {
+        case 'y':
+        case 'Y':
+        case '1':
+        case 't':
+        case 'T':
+            return true;
+
+        case 'n':
+        case 'N':
+        case '0':
+        case 'f':
+        case 'F':
+            return false;
+
+        default:
+            return notfound;
     }
-    return ret;
 }
 
 /*

--- a/core/bh_type.cpp
+++ b/core/bh_type.cpp
@@ -3,8 +3,8 @@ This file is part of Bohrium and copyright (c) 2012 the Bohrium
 team <http://www.bh107.org>.
 
 Bohrium is free software: you can redistribute it and/or modify
-it under the terms of the GNU Lesser General Public License as 
-published by the Free Software Foundation, either version 3 
+it under the terms of the GNU Lesser General Public License as
+published by the Free Software Foundation, either version 3
 of the License, or (at your option) any later version.
 
 Bohrium is distributed in the hope that it will be useful,
@@ -12,8 +12,8 @@ but WITHOUT ANY WARRANTY; without even the implied warranty of
 MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 GNU General Public License for more details.
 
-You should have received a copy of the 
-GNU Lesser General Public License along with Bohrium. 
+You should have received a copy of the
+GNU Lesser General Public License along with Bohrium.
 
 If not, see <http://www.gnu.org/licenses/>.
 */
@@ -105,5 +105,28 @@ const char* bh_type_text(bh_type type)
         return "BH_UNKNOWN";
     default:
         return "Unknown type";
+    }
+}
+
+/* Is type an integer type
+ *
+ * @type   The type.
+ * @return True if integer type.
+ */
+bool bh_type_is_integer(bh_type type)
+{
+    switch(type)
+    {
+    case BH_UINT8:
+    case BH_UINT16:
+    case BH_UINT32:
+    case BH_UINT64:
+    case BH_INT8:
+    case BH_INT16:
+    case BH_INT32:
+    case BH_INT64:
+        return true;
+    default:
+        return false;
     }
 }

--- a/filter/bccon/collect_filter.cpp
+++ b/filter/bccon/collect_filter.cpp
@@ -271,9 +271,9 @@ void collect_filter(bh_ir &bhir)
                     } else {
                         // Is not ADD, SUBTRACT, MULTIPLY, DIVIDE, NONE, FREE, DISCARD
                         // End chain
-                        if (chain.size() > 1) {
+                        if (chain.size() > 1)
                             rewrite_chain(chain);
-                        }
+
                         // Reset
                         chain.clear();
                         views.clear();
@@ -282,6 +282,10 @@ void collect_filter(bh_ir &bhir)
                 }
             }
         }
+
+        // Rewrite if end of instruction list
+        if (chain.size() > 1)
+            rewrite_chain(chain);
 
         chain.clear();
         views.clear();

--- a/filter/bccon/collect_filter.cpp
+++ b/filter/bccon/collect_filter.cpp
@@ -109,10 +109,32 @@ bool is_mul_div(bh_opcode opc)
     return opc == BH_MULTIPLY or opc == BH_DIVIDE;
 }
 
+bool chain_has_same_type(vector<bh_instruction*>& chain)
+{
+    bh_type type = chain.front()->constant.type;
+    for(vector<bh_instruction*>::iterator ite=chain.begin()+1; ite != chain.end(); ++ite) {
+        if (type != (**ite).constant.type)
+            return false;
+    }
+    return true;
+}
+
 void rewrite_chain_add_sub(vector<bh_instruction*>& chain)
 {
     bh_instruction& first = *chain.front();
     bh_instruction& last = *chain.back();
+
+    if (!chain_has_same_type(chain))
+        return;
+
+    switch (first.constant.type) {
+        // Don't know how to do complex types, yet.
+        case BH_BOOL:
+        case BH_COMPLEX64:
+        case BH_COMPLEX128:
+            return;
+    }
+
     float_t sum = 0.0;
 
     // Update first instruction's result base to last
@@ -154,6 +176,18 @@ void rewrite_chain_mul_div(vector<bh_instruction*>& chain)
 {
     bh_instruction& first = *chain.front();
     bh_instruction& last = *chain.back();
+
+    if (!chain_has_same_type(chain))
+        return;
+
+    switch (first.constant.type) {
+        // Don't know how to do complex types, yet.
+        case BH_BOOL:
+        case BH_COMPLEX64:
+        case BH_COMPLEX128:
+            return;
+    }
+
     float_t result = 1.0;
 
     // Update first instruction's result base to last

--- a/filter/bccon/collect_filter.cpp
+++ b/filter/bccon/collect_filter.cpp
@@ -1,0 +1,222 @@
+/*
+This file is part of Bohrium and copyright (c) 2012 the Bohrium
+team <http://www.bh107.org>.
+
+Bohrium is free software: you can redistribute it and/or modify
+it under the terms of the GNU Lesser General Public License as
+published by the Free Software Foundation, either version 3
+of the License, or (at your option) any later version.
+
+Bohrium is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the
+GNU Lesser General Public License along with Bohrium.
+
+If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include <stdio.h>
+#include <set>
+
+#include <bh_component.h>
+#include <bh.h>
+
+using namespace std;
+
+float_t bh_get_value(bh_constant constant)
+{
+    switch(constant.type) {
+        case BH_UINT8:
+            return (float_t)constant.value.uint8;
+        case BH_UINT16:
+            return (float_t)constant.value.uint16;
+        case BH_UINT32:
+            return (float_t)constant.value.uint32;
+        case BH_UINT64:
+            return (float_t)constant.value.uint64;
+
+        case BH_INT8:
+            return (float_t)constant.value.int8;
+        case BH_INT16:
+            return (float_t)constant.value.int16;
+        case BH_INT32:
+            return (float_t)constant.value.int32;
+        case BH_INT64:
+            return (float_t)constant.value.int64;
+
+        case BH_FLOAT32:
+            return (float_t)constant.value.float32;
+        case BH_FLOAT64:
+            return (float_t)constant.value.float64;
+
+        default:
+            fprintf(stderr, "Don't know this type (%s) for collect filter.\n", bh_type_text(constant.type));
+            return 0;
+    }
+}
+
+void bh_set_value(bh_constant* constant, float_t value)
+{
+    switch(constant->type) {
+        case BH_UINT8:
+            constant->value.uint8 = (uint)value;
+            break;
+        case BH_UINT16:
+            constant->value.uint16 = (uint)value;
+            break;
+        case BH_UINT32:
+            constant->value.uint32 = (uint)value;
+            break;
+        case BH_UINT64:
+            constant->value.uint64 = (uint)value;
+            break;
+
+        case BH_INT8:
+            constant->value.int8 = (int)value;
+            break;
+        case BH_INT16:
+            constant->value.int16 = (int)value;
+            break;
+        case BH_INT32:
+            constant->value.int32 = (int)value;
+            break;
+        case BH_INT64:
+            constant->value.int64 = (int)value;
+            break;
+
+        case BH_FLOAT32:
+            constant->value.float32 = value;
+            break;
+        case BH_FLOAT64:
+            constant->value.float64 = value;
+            break;
+
+        default:
+            fprintf(stderr, "Can't set value for this type (%s) for collect filter.\n", bh_type_text(constant->type));
+    }
+}
+
+bool is_add_sub(bh_opcode opc)
+{
+    return opc == BH_ADD or opc == BH_SUBTRACT;
+}
+
+bool is_mul_div(bh_opcode opc)
+{
+    return opc == BH_MULTIPLY or opc == BH_DIVIDE;
+}
+
+void rewrite_chain_add_sub(vector<bh_instruction*>& chain)
+{
+    bh_instruction& first = *chain.front();
+    bh_instruction& last = *chain.back();
+    float_t sum = 0.0;
+
+    // Update first instruction's result base to last
+    first.operand[0].base = last.operand[0].base;
+
+    // Get first instructions value
+    if (first.opcode == BH_ADD) {
+        sum += bh_get_value(first.constant);
+    } else {
+        sum -= bh_get_value(first.constant);
+    }
+
+    // Loop through rest and accumulate value
+    for(vector<bh_instruction*>::iterator ite=chain.begin()+1; ite != chain.end(); ++ite) {
+        bh_instruction& rinstr = **ite;
+        if (rinstr.opcode == BH_ADD) {
+            sum += bh_get_value(rinstr.constant);
+        } else {
+            sum -= bh_get_value(rinstr.constant);
+        }
+        // Remove instruction
+        rinstr.opcode = BH_NONE;
+    }
+
+    // We might have to reverse the original first opcode
+    // If sum is below zero, we want to subtract
+    if (sum < 0) {
+        first.opcode = BH_SUBTRACT;
+        sum = -sum;
+    } else {
+        first.opcode = BH_ADD;
+    }
+
+    // Set first instruction's new value
+    bh_set_value(&(first.constant), sum);
+}
+
+void rewrite_chain_mul_div(vector<bh_instruction*>& chain)
+{
+    // TODO Implement
+}
+
+void rewrite_chain(vector<bh_instruction*>& chain)
+{
+    bh_opcode opc = chain[0]->opcode;
+    if (is_add_sub(opc)) {
+        rewrite_chain_add_sub(chain);
+    } else if (is_mul_div(opc)) {
+        rewrite_chain_mul_div(chain);
+    }
+}
+
+void collect_filter(bh_ir &bhir)
+{
+    bh_opcode collect_opcode = BH_NONE;
+    vector<bh_view*> views;
+    vector<bh_instruction*> chain;
+
+    for(size_t pc = 0; pc < bhir.instr_list.size(); ++pc) {
+        bh_instruction& instr = bhir.instr_list[pc];
+
+        if ((is_add_sub(instr.opcode) or is_mul_div(instr.opcode)) and bh_is_constant(&(instr.operand[2]))) {
+            collect_opcode = instr.opcode;
+            views.push_back(&instr.operand[0]);
+            chain.push_back(&instr);
+
+            for(size_t pc_chain = pc+1; pc_chain < bhir.instr_list.size(); ++pc_chain) {
+                bh_instruction& other_instr = bhir.instr_list[pc_chain];
+
+                if (is_add_sub(collect_opcode) and is_add_sub(other_instr.opcode) and bh_is_constant(&instr.operand[2])) {
+                    // Both are ADD or SUBTRACT
+                    if (*views.back() == other_instr.operand[1]) {
+                        views.push_back(&other_instr.operand[0]);
+                        chain.push_back(&other_instr);
+                    }
+                } else if (is_mul_div(collect_opcode) and is_mul_div(other_instr.opcode) and bh_is_constant(&instr.operand[2])) {
+                    // Both are MULTIPLY or DIVIDE
+                    if (*views.back() == other_instr.operand[1]) {
+                        views.push_back(&other_instr.operand[0]);
+                        chain.push_back(&other_instr);
+                    }
+                } else {
+                    bool is_none      = other_instr.opcode == BH_NONE;
+                    bool is_freed     = other_instr.opcode == BH_FREE;
+                    bool is_discarded = other_instr.opcode == BH_DISCARD;
+
+                    if (is_none or is_freed or is_discarded) {
+                        continue;
+                    } else {
+                        // Is not ADD, SUBTRACT, MULTIPLY, DIVIDE, NONE, FREE, DISCARD
+                        // End chain
+                        if (!chain.empty()) {
+                            rewrite_chain(chain);
+                        }
+                        // Reset
+                        chain.clear();
+                        views.clear();
+                        break;
+                    }
+                }
+            }
+        }
+
+        chain.clear();
+        views.clear();
+    }
+}

--- a/filter/bccon/collect_filter.cpp
+++ b/filter/bccon/collect_filter.cpp
@@ -237,7 +237,7 @@ void collect_filter(bh_ir &bhir)
                     } else {
                         // Is not ADD, SUBTRACT, MULTIPLY, DIVIDE, NONE, FREE, DISCARD
                         // End chain
-                        if (!chain.empty()) {
+                        if (chain.size() > 1) {
                             rewrite_chain(chain);
                         }
                         // Reset

--- a/filter/bccon/collect_filter.hpp
+++ b/filter/bccon/collect_filter.hpp
@@ -1,0 +1,1 @@
+void collect_filter(bh_ir &bhir);

--- a/filter/bccon/component_interface.cpp
+++ b/filter/bccon/component_interface.cpp
@@ -34,7 +34,7 @@ static bh_component myself; // Myself
 // Function pointers to our child.
 static bh_component_iface *child;
 
-static bh_intp reduction_;
+static bool reduction_;
 
 // The timing ID for the filter
 static bh_intp exec_timing;
@@ -67,9 +67,7 @@ bh_error bh_filter_bccon_init(const char* name)
         return err;
     }
 
-    if (BH_SUCCESS != bh_component_config_int_option(&myself, "reduction", 0, 1, &reduction_)) {
-        return BH_ERROR;
-    }
+    reduction_ = bh_component_config_lookup_bool(&myself, "reduction", false);
 
     return BH_SUCCESS;
 }
@@ -93,9 +91,10 @@ bh_error bh_filter_bccon_execute(bh_ir* bhir)
     bh_uint64 start = 0;
     if (timing)
         start = bh_timer_stamp();
-    if (reduction_) {
-        reduction_chain_filter(*bhir); // Run the filter
-    }
+
+    if (reduction_) reduction_chain_filter(*bhir);
+    if (collect_)   collect_filter(*bhir);
+
     if (timing)
         bh_timer_add(exec_timing, start, bh_timer_stamp());
 

--- a/filter/bccon/component_interface.cpp
+++ b/filter/bccon/component_interface.cpp
@@ -24,6 +24,7 @@ If not, see <http://www.gnu.org/licenses/>.
 
 #include "component_interface.h"
 #include "reduction_chain_filter.hpp"
+#include "collect_filter.hpp"
 
 //
 // Components
@@ -34,7 +35,7 @@ static bh_component myself; // Myself
 // Function pointers to our child.
 static bh_component_iface *child;
 
-static bool reduction_;
+static bool reduction_, collect_;
 
 // The timing ID for the filter
 static bh_intp exec_timing;
@@ -68,6 +69,7 @@ bh_error bh_filter_bccon_init(const char* name)
     }
 
     reduction_ = bh_component_config_lookup_bool(&myself, "reduction", false);
+    collect_   = bh_component_config_lookup_bool(&myself, "collect",   false);
 
     return BH_SUCCESS;
 }

--- a/include/bh.h
+++ b/include/bh.h
@@ -90,6 +90,13 @@ DLLEXPORT int bh_type_size(bh_type type);
  */
 DLLEXPORT const char* bh_type_text(bh_type type);
 
+/* Is type an integer type
+ *
+ * @type   The type.
+ * @return True if integer type.
+ */
+DLLEXPORT bool bh_type_is_integer(bh_type type);
+
 /* Determines whether the opcode is a sweep opcode
  * i.e. either a reduction or an accumulate
  *
@@ -114,4 +121,3 @@ std::ostream& operator<<(std::ostream& out, const std::vector<E>& v)
 }
 
 #endif
-


### PR DESCRIPTION
A program with multiple add/subtract in a chain will be collected into one add/subtract operation.

Example:

```python
import numpy as np
z = np.array([[1, 2, 3], [4, 5, 6], [7, 8, 9]])

z -= 5
z += 1
z += 1
z += 1
z += 1
z += 1

z = z + 2
z += 8

print z
```

will have the following trace before:

```
BH_SUBTRACT a0[0:3:3,0:3:1] a0[0:3:3,0:3:1] 5
BH_ADD a0[0:3:3,0:3:1] a0[0:3:3,0:3:1] 1
BH_ADD a0[0:3:3,0:3:1] a0[0:3:3,0:3:1] 1
BH_ADD a0[0:3:3,0:3:1] a0[0:3:3,0:3:1] 1
BH_ADD a0[0:3:3,0:3:1] a0[0:3:3,0:3:1] 1
BH_ADD a0[0:3:3,0:3:1] a0[0:3:3,0:3:1] 1
BH_ADD a1[0:3:3,0:3:1] a0[0:3:3,0:3:1] 2
BH_FREE a0[0:9:1]
BH_DISCARD a0[0:9:1]
BH_ADD a1[0:3:3,0:3:1] a1[0:3:3,0:3:1] 8
BH_SYNC a1[0:3:3,0:3:1]
BH_DISCARD a1[0:3:3,0:3:1]
```

and after:

```
BH_ADD a1[0:3:3,0:3:1] a0[0:3:3,0:3:1] 10
BH_NONE
BH_NONE
BH_NONE
BH_NONE
BH_NONE
BH_NONE
BH_FREE a0[0:9:1]
BH_DISCARD a0[0:9:1]
BH_NONE
BH_SYNC a1[0:3:3,0:3:1]
BH_DISCARD a1[0:3:3,0:3:1]
```

---

```python
import numpy as np
z = np.ones((200, 200, 200))
for _ in xrange(1500):
    z += 1
print z
```

The above has a speed up of a factor of ~20 when running with Bohrium compared to vanilla Python.