### PR TITLE
BH_REPEAT

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,8 +8,9 @@ language: c
 compiler:
   - gcc
 
-install:
-    - docker build -t bohrium_release -f package/docker/ubuntu14.04/bohrium.dockerfile .
+before_install:
+  - docker pull bohrium/ubuntu:14.04
+  - docker build -t bohrium_release -f package/docker/ubuntu14.04/bohrium.dockerfile .
 
 env:
   global:
@@ -17,15 +18,17 @@ env:
       - BH_GPU_TROUBLESOME="--exclude-test=test_lbm_3d"
       - BH_CPU_TROUBLESOME="--exclude-test=test_lbm_3d"
   matrix:
+      # Default stack
       - BH_STACK=stack_default BH_CPU_JIT_LEVEL=3 NUMPYTEST_ARGS=$BH_CPU_TROUBLESOME
       - BH_STACK=stack_default BH_CPU_JIT_LEVEL=1 NUMPYTEST_ARGS=$BH_CPU_TROUBLESOME
+
+      # CPU greedy stack
       - BH_STACK=stack_cpu_greedy BH_CPU_JIT_LEVEL=3 NUMPYTEST_ARGS=$BH_CPU_TROUBLESOME
       - BH_STACK=stack_cpu_greedy BH_CPU_JIT_LEVEL=1 NUMPYTEST_ARGS=$BH_CPU_TROUBLESOME
 
+      # GPU stack
       - BH_STACK=stack_gpu NUMPYTEST_ARGS=$BH_GPU_TROUBLESOME BH_BCEXP_GPU_REDUCE1D=100
-#      - BH_STACK=stack_gpu NUMPYTEST_ARGS=$BH_GPU_TROUBLESOME BH_BCEXP_GPU_REDUCE1D=100 BH_GPU_COMPILE=async
-#      - BH_STACK=stack_gpu NUMPYTEST_ARGS=$BH_GPU_TROUBLESOME BH_FUSE_MODEL=NO_XSWEEP_SCALAR_SEPERATE
-#      - BH_STACK=stack_gpu NUMPYTEST_ARGS=$BH_GPU_TROUBLESOME BH_FUSE_MODEL=NO_XSWEEP_SCALAR_SEPERATE BH_GPU_COMPILE=async
+
 notifications:
   slack: bohrium:BCAEW8qYK5fmkt8f5mW95GUe
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -99,7 +99,7 @@ set_package_properties(PythonInterp PROPERTIES DESCRIPTION "Python Programming L
 set_package_properties(PythonInterp PROPERTIES TYPE REQUIRED PURPOSE "Python is required to build Bohrium")
 message(STATUS "Python found: ${PYTHON_EXECUTABLE}")
 
-find_package(Boost REQUIRED COMPONENTS serialization filesystem system thread)      # Everything
+find_package(Boost REQUIRED COMPONENTS serialization filesystem system thread regex)      # Everything
 set_package_properties(Boost PROPERTIES DESCRIPTION "Boost C++ source libraries" URL "www.boost.org")
 set_package_properties(Boost PROPERTIES TYPE REQUIRED PURPOSE "Boost is required to build Bohrium")
 include_directories(${Boost_INCLUDE_DIRS})

--- a/bridge/c/gen_array_operations.py
+++ b/bridge/c/gen_array_operations.py
@@ -23,7 +23,7 @@ def main(args):
     # Let's generate the header and implementation of all array operations
     head = ""; impl = ""
     for op in opcodes:
-        if op['opcode'] in ["BH_RANDOM", "BH_NONE"]:#We handle random separately and ignore None
+        if op['opcode'] in ["BH_REPEAT", "BH_RANDOM", "BH_NONE"]:#We handle random separately and ignore None
             continue
         doc = "// %s: %s\n"%(op['opcode'][3:], op['doc'])
         doc += "// E.g. %s:\n"%(op['code'])

--- a/bridge/cil/gen_array_operations.py
+++ b/bridge/cil/gen_array_operations.py
@@ -25,7 +25,7 @@ def main(args):
     # Let's generate the header and implementation of all array operations
     head = ""
     for op in opcodes:
-        if op['opcode'] in ["BH_RANDOM", "BH_NONE"]:#We handle random separately and ignore None
+        if op['opcode'] in ["BH_REPEAT", "BH_RANDOM", "BH_NONE"]:#We handle random separately and ignore None
             continue
 
         # Generate functions that takes no operands
@@ -76,8 +76,8 @@ This file is part of Bohrium and copyright (c) 2013 the Bohrium
 team <http://www.bh107.org>.
 
 Bohrium is free software: you can redistribute it and/or modify
-it under the terms of the GNU Lesser General Public License as 
-published by the Free Software Foundation, either version 3 
+it under the terms of the GNU Lesser General Public License as
+published by the Free Software Foundation, either version 3
 of the License, or (at your option) any later version.
 
 Bohrium is distributed in the hope that it will be useful,
@@ -85,8 +85,8 @@ but WITHOUT ANY WARRANTY; without even the implied warranty of
 MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 GNU General Public License for more details.
 
-You should have received a copy of the 
-GNU Lesser General Public License along with Bohrium. 
+You should have received a copy of the
+GNU Lesser General Public License along with Bohrium.
 
 If not, see <http://www.gnu.org/licenses/>.
 */
@@ -113,7 +113,7 @@ using bh_complex128 = System.Numerics.Complex;
 
 namespace NumCIL.Bohrium
 {
-    internal static partial class PInvoke 
+    internal static partial class PInvoke
     {
 
 %s

--- a/bridge/cpp/bxx/runtime.operations.hpp
+++ b/bridge/cpp/bxx/runtime.operations.hpp
@@ -1348,6 +1348,15 @@ void bh_discard (multi_array<T>& res)
     Runtime::instance().enqueue((bh_opcode)BH_DISCARD, res);
 }
 
+// bh_repeat - BH_REPEAT - runtime.nops1 - 1 (A)
+template <typename T>
+inline
+void bh_repeat (multi_array<T>& res)
+{
+    Runtime::instance().typecheck<BH_REPEAT, T>();
+    Runtime::instance().enqueue((bh_opcode)BH_REPEAT, res);
+}
+
 
 // bh_random - BH_RANDOM - runtime.random - 2 (A,K,K)
 template <typename T>

--- a/bridge/cpp/bxx/runtime.typechecker.hpp
+++ b/bridge/cpp/bxx/runtime.typechecker.hpp
@@ -2963,6 +2963,11 @@ void Runtime::typecheck<BH_REAL, float, std::complex<float> >(void) { }
 
 template <>
 inline
+void Runtime::typecheck<BH_REPEAT, uint64_t, uint64_t>(void) { }
+
+
+template <>
+inline
 void Runtime::typecheck<BH_RIGHT_SHIFT, int16_t, int16_t, int16_t>(void) { }
 
 
@@ -3178,11 +3183,6 @@ void Runtime::typecheck<BH_SQRT, double, double>(void) { }
 
 template <>
 inline
-void Runtime::typecheck<BH_SUBTRACT, bool, bool, bool>(void) { }
-
-
-template <>
-inline
 void Runtime::typecheck<BH_SUBTRACT, std::complex<double> , std::complex<double> , std::complex<double> >(void) { }
 
 
@@ -3357,3 +3357,4 @@ void Runtime::typecheck<BH_TRUNC, double, double>(void) { }
 
 }
 #endif
+

--- a/bridge/cpp/bxx/runtime.typechecker.hpp
+++ b/bridge/cpp/bxx/runtime.typechecker.hpp
@@ -3357,4 +3357,3 @@ void Runtime::typecheck<BH_TRUNC, double, double>(void) { }
 
 }
 #endif
-

--- a/bridge/cpp/codegen/gen.py
+++ b/bridge/cpp/codegen/gen.py
@@ -124,6 +124,10 @@ def main():
             nop = 3
             typesigs = [(u'uint64_t', u'uint64_t', u'uint64_t')]
             op = (fun, enum, template, nop, typesigs, layouts, broadcast)
+        elif enum == "BH_REPEAT":
+            nop = 2
+            typesigs = [(u'uint64_t', u'uint64_t')]
+            op = (fun, enum, template, nop, typesigs, layouts, broadcast)
 
         if enum not in enums:
             checker.append(op)

--- a/bridge/cpp/codegen/operators.json
+++ b/bridge/cpp/codegen/operators.json
@@ -1,11 +1,11 @@
 [
 ["=",               "BH_IDENTITY",  "sugar.nops2.intern",  false],
 ["bh_identity",     "BH_IDENTITY",  "runtime.nops2",    true],
-    
+
 ["[]",              "CUSTOM_2",      "operator.intern", false],
 ["()",              "CUSTOM_2",      "operator.intern", false],
 ["->",              "CUSTOM_2",      "operator.intern", false],
-    
+
 ["++",              "CUSTOM_2",      "operator.extern.prefix",  true],
 ["++",              "CUSTOM_2",      "operator.extern.postfix", true],
 ["--",              "CUSTOM_2",      "operator.extern.prefix",  true],
@@ -15,22 +15,22 @@
 ["operator+",       "BH_ADD",   "sugar.nops3",     true],
 ["operator+=",      "BH_ADD",   "sugar.nops3.intern", true],
 ["bh_add",          "BH_ADD",   "runtime.nops3",   true],
-    
+
 ["subtract",        "BH_SUBTRACT",  "sugar.nops3",     true],
 ["operator-",       "BH_SUBTRACT",  "sugar.nops3",     true],
 ["operator-=",      "BH_SUBTRACT",  "sugar.nops3.intern", true],
 ["bh_subtract",     "BH_SUBTRACT",  "runtime.nops3",   true],
-    
+
 ["mul",             "BH_MULTIPLY",  "sugar.nops3",     true],
 ["operator*",       "BH_MULTIPLY",  "sugar.nops3",     true],
 ["operator*=",      "BH_MULTIPLY",  "sugar.nops3.intern", true],
 ["bh_multiply",     "BH_MULTIPLY",  "runtime.nops3",   true],
-    
+
 ["div",             "BH_DIVIDE",    "sugar.nops3",     true],
 ["operator/",       "BH_DIVIDE",    "sugar.nops3",     true],
 ["operator/=",      "BH_DIVIDE",    "sugar.nops3.intern", true],
 ["bh_divide",       "BH_DIVIDE",    "runtime.nops3",   true],
-    
+
 ["mod",             "BH_MOD",   "sugar.nops3",     true],
 ["operator%",       "BH_MOD",   "sugar.nops3",     true],
 ["operator%=",      "BH_MOD",   "sugar.nops3.intern", true],
@@ -161,34 +161,34 @@
 
 ["exp",             "BH_EXP",       "sugar.nops2",      true],
 ["bh_exp",          "BH_EXP",       "runtime.nops2",    true],
-        
+
 ["exp2",            "BH_EXP2",      "sugar.nops2",      true],
 ["bh_exp2",         "BH_EXP2",      "runtime.nops2",    true],
-        
+
 ["expm1",           "BH_EXPM1",     "sugar.nops2",      true],
 ["bh_expm1",        "BH_EXPM1",     "runtime.nops2",    true],
-        
+
 ["isnan",           "BH_ISNAN", "sugar.nops2.bool",     true],
 ["bh_isnan",        "BH_ISNAN", "runtime.nops2",   true],
-        
+
 ["isinf",           "BH_ISINF", "sugar.nops2.bool",     true],
 ["bh_isinf",        "BH_ISINF", "runtime.nops2",   true],
-        
+
 ["log",             "BH_LOG",   "sugar.nops2",      true],
 ["bh_log",          "BH_LOG",   "runtime.nops2",    true],
-        
+
 ["log2",            "BH_LOG2",  "sugar.nops2",      true],
 ["bh_log2",         "BH_LOG2",  "runtime.nops2",    true],
-        
+
 ["log10",           "BH_LOG10", "sugar.nops2",      true],
 ["bh_log10",        "BH_LOG10", "runtime.nops2",    true],
-        
+
 ["log1p",           "BH_LOG1P", "sugar.nops2",      true],
 ["bh_log1p",        "BH_LOG1P", "runtime.nops2",    true],
-        
+
 ["sqrt",            "BH_SQRT",  "sugar.nops2",      true],
 ["bh_sqrt",         "BH_SQRT",  "runtime.nops2",    true],
-        
+
 ["ceil",            "BH_CEIL",  "sugar.nops2",      true],
 ["bh_ceil",         "BH_CEIL",  "runtime.nops2",    true],
 

--- a/bridge/cpp/codegen/operators.json
+++ b/bridge/cpp/codegen/operators.json
@@ -234,6 +234,7 @@
 ["bh_tally",    "BH_TALLY",     "runtime.nops0", true],
 ["bh_free",     "BH_FREE",      "runtime.nops1", true],
 ["bh_sync",     "BH_SYNC",      "runtime.nops1", true],
-["bh_discard",  "BH_DISCARD",   "runtime.nops1", true]
+["bh_discard",  "BH_DISCARD",   "runtime.nops1", true],
+["bh_repeat",   "BH_REPEAT",    "runtime.nops1", true]
 
 ]

--- a/config.ini.in
+++ b/config.ini.in
@@ -214,6 +214,7 @@ impl = ${CMAKE_INSTALL_PREFIX}/lib/libbh_filter_bccon${CMAKE_SHARED_LIBRARY_SUFF
 children = node
 reduction = true
 collect = true
+find_repeats = false
 stupidmath = true
 timing = false
 
@@ -232,6 +233,7 @@ matmul = 1
 sign = 1
 powk = 1
 reduce1d = 0
+repeat = 0
 timing = false
 
 [bcexp_gpu]
@@ -243,6 +245,7 @@ matmul = 1
 sign = 1
 powk = 1
 reduce1d = 32000
+repeat = 0
 timing = false
 
 [bcexp_cpu]
@@ -254,6 +257,7 @@ matmul = 1
 sign = 0
 powk = 1
 reduce1d = 0
+repeat = 0
 timing = false
 
 #

--- a/core/bh_pprint.cpp
+++ b/core/bh_pprint.cpp
@@ -188,18 +188,20 @@ void bh_sprint_instr(const bh_instruction *instr, char buf[], const char newline
     char op_str[PPRINT_BUF_OPSTR_SIZE];
     char tmp[PPRINT_BUF_OPSTR_SIZE];
     int op_count = bh_noperands(instr->opcode);
-    int i;
-    if(instr->opcode > BH_MAX_OPCODE_ID)//It is a extension method
-        sprintf(buf, "Extension Method (%d) OPS=%d{%s", (int)instr->opcode, op_count, newline);
-    else
-        sprintf(buf, "%s OPS=%d{%s", bh_opcode_text(instr->opcode), op_count, newline);
-    for(i=0; i < op_count; i++) {
 
-        if (!bh_is_constant(&instr->operand[i]))
+    if(instr->opcode > BH_MAX_OPCODE_ID) { //It is a extension method
+        sprintf(buf, "Extension Method (%d) OPS=%d{%s", (int)instr->opcode, op_count, newline);
+    } else {
+        sprintf(buf, "%s OPS=%d{%s", bh_opcode_text(instr->opcode), op_count, newline);
+    }
+
+    for(int i = 0; i < op_count; i++) {
+        if (!bh_is_constant(&instr->operand[i])) {
             bh_sprint_view(&instr->operand[i], op_str );
-        else
+        } else {
             //sprintf(op_str, "CONSTANT");
             bh_sprint_const(&instr->constant, op_str );
+        }
 
         sprintf(tmp, "  OP%d %s%s", i, op_str, newline);
         strcat(buf, tmp);
@@ -213,7 +215,6 @@ void bh_sprint_instr(const bh_instruction *instr, char buf[], const char newline
  */
 void bh_pprint_instr(const bh_instruction *instr)
 {
-
     char buf[PPRINT_BUF_SIZE];
     bh_sprint_instr( instr, buf, "\n" );
     puts( buf );
@@ -301,4 +302,3 @@ void bh_pprint_trace_file(const bh_ir *bhir, char trace_fn[])
     }
     fclose(file);
 }
-

--- a/core/codegen/opcodes.json
+++ b/core/codegen/opcodes.json
@@ -2055,6 +2055,24 @@
     "reduction":     false,
     "accumulate":    false,
     "system_opcode": false
+},
+{
+    "opcode": "BH_REPEAT",
+    "doc": "",
+    "code": "",
+    "id": "79",
+    "nop": 1,
+    "types": [
+        [ "BH_R123" ]
+    ],
+    "layout": [
+        [ "K" ]
+    ],
+    "elementwise":   false,
+    "composite":     false,
+    "reduction":     false,
+    "accumulate":    false,
+    "system_opcode": true
 }
 
 ]

--- a/doc/source/installation/linux.rst
+++ b/doc/source/installation/linux.rst
@@ -105,7 +105,7 @@ You need to install all packages required to build NumPy::
 
 And some additional packages::
 
-  sudo apt-get install python-numpy python-dev swig python-cheetah cmake unzip cython libhwloc-dev libboost-filesystem-dev libboost-serialization-dev libboost-thread-dev libboost-thread-dev libboost-system-dev  zlib1g-dev
+  sudo apt-get install python-numpy python-dev swig python-cheetah cmake unzip cython libhwloc-dev libboost-filesystem-dev libboost-serialization-dev libboost-thread-dev libboost-regex-dev libboost-system-dev  zlib1g-dev
 
 Packages for visualization::
 
@@ -255,4 +255,3 @@ You should now have everything you need to utilize the GPU engine.
 ..
 ..
 .. .. warning:: The cluster engine is in a significantly less developed state than both the CPU and GPU engine.
-

--- a/filter/bccon/component_interface.cpp
+++ b/filter/bccon/component_interface.cpp
@@ -25,6 +25,7 @@ If not, see <http://www.gnu.org/licenses/>.
 #include "component_interface.h"
 #include "reduction_chain_filter.hpp"
 #include "collect_filter.hpp"
+#include "find_repeats_filter.hpp"
 #include "stupid_math_filter.hpp"
 
 //
@@ -36,7 +37,7 @@ static bh_component myself; // Myself
 // Function pointers to our child.
 static bh_component_iface *child;
 
-static bool reduction_, stupidmath_, collect_;
+static bool find_repeats_, reduction_, stupidmath_, collect_;
 
 // The timing ID for the filter
 static bh_intp exec_timing;
@@ -69,9 +70,10 @@ bh_error bh_filter_bccon_init(const char* name)
         return err;
     }
 
-    reduction_  = bh_component_config_lookup_bool(&myself, "reduction",  false);
-    stupidmath_ = bh_component_config_lookup_bool(&myself, "stupidmath", false);
-    collect_    = bh_component_config_lookup_bool(&myself, "collect",    false);
+    find_repeats_ = bh_component_config_lookup_bool(&myself, "find_repeats", false);
+    reduction_    = bh_component_config_lookup_bool(&myself, "reduction",    false);
+    stupidmath_   = bh_component_config_lookup_bool(&myself, "stupidmath",   false);
+    collect_      = bh_component_config_lookup_bool(&myself, "collect",      false);
 
     return BH_SUCCESS;
 }
@@ -96,9 +98,10 @@ bh_error bh_filter_bccon_execute(bh_ir* bhir)
     if (timing)
         start = bh_timer_stamp();
 
-    if (reduction_)  reduction_chain_filter(*bhir);
-    if (stupidmath_) stupid_math_filter(*bhir);
-    if (collect_)    collect_filter(*bhir);
+    if (find_repeats_) find_repeats_filter(*bhir);
+    if (reduction_)    reduction_chain_filter(*bhir);
+    if (stupidmath_)   stupid_math_filter(*bhir);
+    if (collect_)      collect_filter(*bhir);
 
     if (timing)
         bh_timer_add(exec_timing, start, bh_timer_stamp());

--- a/filter/bccon/find_repeats_filter.cpp
+++ b/filter/bccon/find_repeats_filter.cpp
@@ -1,0 +1,135 @@
+/*
+This file is part of Bohrium and copyright (c) 2012 the Bohrium
+team <http://www.bh107.org>.
+
+Bohrium is free software: you can redistribute it and/or modify
+it under the terms of the GNU Lesser General Public License as
+published by the Free Software Foundation, either version 3
+of the License, or (at your option) any later version.
+
+Bohrium is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the
+GNU Lesser General Public License along with Bohrium.
+
+If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include <boost/regex.hpp>
+#include <iostream>
+#include <string>
+#include <unordered_map>
+
+#include <bh_component.h>
+
+using namespace std;
+
+// Regex matcher. This regex will match all repeating groups in a string
+// ie. will match 'bc' in 'abcbcbcde'
+static const boost::regex re("\\A(.+)\\1+\\z");
+
+// Convert the instruction list to a string of characters
+// Identical instructions will be mapped to the same character
+string bh_instr_list_to_string(const vector<bh_instruction> &instr_list, unordered_map<char, const bh_instruction*> &identifier_map)
+{
+    string result = "";
+    char identifier = (char)((int) 'a' - 1);
+
+    for(const bh_instruction &instr : instr_list) {
+        bool seen = false;
+
+        // See if we have already seen this instruction before
+        for (const auto it : identifier_map) {
+            if (*it.second == instr) {
+                identifier = it.first;
+                seen = true;
+                break;
+            }
+        }
+
+        // If we haven't seen the instruction before, update the identifier and add it to the map
+        if (!seen) {
+            identifier = (char)((int) identifier + 1);
+            identifier_map[identifier] = &instr;
+        }
+
+        result += identifier;
+    }
+
+    return result;
+}
+
+// Count occurrences of str2 in str1
+int count_occur(string str1, string str2)
+{
+    int occur = 0;
+    int start = 0;
+
+    while ((start = str1.find(str2, start)) < str1.length()) {
+        ++occur;
+        start += str2.length();
+    }
+
+    return occur;
+}
+
+void find_repeats_filter(bh_ir &bhir)
+{
+    // Build map of instructions and string representation of instruction list
+    unordered_map<char, const bh_instruction*> identifier_map;
+    const string bh_string_instr_list = bh_instr_list_to_string(bhir.instr_list, identifier_map);
+
+    boost::smatch matches;
+
+    try {
+        if (boost::regex_search(bh_string_instr_list.begin(), bh_string_instr_list.end(), matches, re)) {
+            int size  = matches.str(1).size(); // How many instructions
+            int occur = count_occur(matches.str(0), matches.str(1)); // How many repeats
+
+            // Replace the matches with 'R'
+            string instr_list_str;
+            boost::regex_replace(back_inserter(instr_list_str), bh_string_instr_list.begin(), bh_string_instr_list.end(), re, "R");
+
+            vector<bh_instruction> new_bh_instr_list;
+
+            for(const char c : instr_list_str) {
+                // A 'R' means we have found our repeating sequence
+                if (c == 'R') {
+                    // Create a BH_REPEAT instruction
+                    bh_instruction repeat_instr;
+                    repeat_instr.opcode = BH_REPEAT;
+                    repeat_instr.operand[0].base = NULL;
+
+                    // We use the BH_R123 type, because this can hold two values
+                    bh_constant constant;
+                    constant.type = BH_R123;
+                    constant.value.r123.start = size;
+                    constant.value.r123.key = occur;
+                    repeat_instr.constant = constant;
+
+                    // BH_REPEAT is pushed to new instruction list
+                    new_bh_instr_list.push_back(repeat_instr);
+
+                    // Push inner part of the repeat to new instruction list
+                    for(const char d : matches.str(1)) {
+                        new_bh_instr_list.push_back(*identifier_map.find(d)->second);
+                    }
+                } else {
+                    // This is a regular instruction. Push as is.
+                    new_bh_instr_list.push_back(*identifier_map.find(c)->second);
+                }
+            }
+
+            // Set new instruction list
+            bhir.instr_list = new_bh_instr_list;
+        }
+    } catch(std::runtime_error& e) {
+        printf("Regex failed - Moving on\n");
+        return;
+    }
+
+    return;
+}

--- a/filter/bccon/find_repeats_filter.hpp
+++ b/filter/bccon/find_repeats_filter.hpp
@@ -1,0 +1,1 @@
+void find_repeats_filter(bh_ir &bhir);

--- a/filter/bcexp/component_interface.cpp
+++ b/filter/bcexp/component_interface.cpp
@@ -65,11 +65,12 @@ bh_error bh_filter_bcexp_init(const char* name)
         return err;
     }
 
-    bh_intp gc_threshold, sign, matmul, powk,reduce1d;
+    bh_intp gc_threshold, sign, matmul, powk, repeat, reduce1d;
     if ((BH_SUCCESS!=bh_component_config_int_option(&myself, "gc_threshold", 0, 2000, &gc_threshold)) or \
         (BH_SUCCESS!=bh_component_config_int_option(&myself, "matmul", 0, 1, &matmul)) or \
         (BH_SUCCESS!=bh_component_config_int_option(&myself, "sign", 0, 1, &sign)) or \
-        (BH_SUCCESS!=bh_component_config_int_option(&myself, "powk", 0, 1, &powk))) {
+        (BH_SUCCESS!=bh_component_config_int_option(&myself, "powk", 0, 1, &powk)) or \
+        (BH_SUCCESS!=bh_component_config_int_option(&myself, "repeat", 0, 1, &repeat))) {
         return BH_ERROR;
     }
     reduce1d = bh_component_config_lookup_int(&myself, "reduce1d", 0);
@@ -78,7 +79,8 @@ bh_error bh_filter_bcexp_init(const char* name)
                                                             matmul,
                                                             sign,
                                                             powk,
-                                                            reduce1d);
+                                                            reduce1d,
+                                                            repeat);
     } catch (std::bad_alloc& ba) {
         fprintf(stderr, "Failed constructing Expander due to allocation error.\n");
     }

--- a/filter/bcexp/expand_repeat.cpp
+++ b/filter/bcexp/expand_repeat.cpp
@@ -1,0 +1,53 @@
+/*
+This file is part of Bohrium and copyright (c) 2012 the Bohrium
+team <http://www.bh107.org>.
+
+Bohrium is free software: you can redistribute it and/or modify
+it under the terms of the GNU Lesser General Public License as
+published by the Free Software Foundation, either version 3
+of the License, or (at your option) any later version.
+
+Bohrium is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the
+GNU Lesser General Public License along with Bohrium.
+
+If not, see <http://www.gnu.org/licenses/>.
+*/
+#include "expander.hpp"
+#include <math.h>
+
+using namespace std;
+
+namespace bohrium {
+namespace filter {
+namespace composite {
+
+int Expander::expand_repeat(bh_ir& bhir, int pc)
+{
+    // Grab the BH_REPEAT instruction
+    bh_instruction& instr = bhir.instr_list[pc];
+
+    // Get the two arguments, which are enclosed in the constant of type BH_R123
+    int size = instr.constant.value.r123.start;
+    int occur = instr.constant.value.r123.key;
+
+    // Remove BH_REPEAT
+    instr.opcode = BH_NONE;
+
+    // Repeat content of BH_REPEAT occur-1 times.
+    // -1 since it's already there once
+    for (int i = 0; i < occur-1; ++i) {
+        for (int j = 0; j < size; ++j) {
+            ++pc;
+            inject(bhir, pc, bhir.instr_list[pc + j]);
+        }
+    }
+
+    return size * occur;
+}
+
+}}}

--- a/filter/bcexp/expander.cpp
+++ b/filter/bcexp/expander.cpp
@@ -27,8 +27,8 @@ namespace composite {
 
 const char Expander::TAG[] = "Expander";
 
-Expander::Expander(size_t threshold, int matmul, int sign, int powk, int reduce1d)
-    : gc_threshold_(threshold), matmul_(matmul), sign_(sign), powk_(powk), reduce1d_(reduce1d){}
+Expander::Expander(size_t threshold, int matmul, int sign, int powk, int reduce1d, int repeat)
+    : gc_threshold_(threshold), matmul_(matmul), sign_(sign), powk_(powk), reduce1d_(reduce1d), repeat_(repeat){}
 
 void Expander::expand(bh_ir& bhir)
 {
@@ -57,6 +57,14 @@ void Expander::expand(bh_ir& bhir)
         case BH_SIGN:
             if (sign_) {
                 increase = expand_sign(bhir, pc);
+                end += increase;
+                pc += increase;
+            }
+            break;
+
+        case BH_REPEAT:
+            if (repeat_) {
+                increase = expand_repeat(bhir, pc);
                 end += increase;
                 pc += increase;
             }

--- a/filter/bcexp/expander.hpp
+++ b/filter/bcexp/expander.hpp
@@ -16,7 +16,7 @@ public:
     /**
      *  Construct the expander.
      */
-    Expander(size_t threshold, int matmul, int sign, int powk, int reduce_1d);
+    Expander(size_t threshold, int matmul, int sign, int powk, int reduce_1d, int repeat);
 
     /**
      *  Tear down the expander.
@@ -57,6 +57,7 @@ public:
 
     // System instruction
     void inject(bh_ir& bhir, int pc, bh_opcode opcode, bh_view& out);
+    inline void inject(bh_ir& bhir, int pc, bh_instruction instr);
 
     // Unary instruction
     void inject(bh_ir& bhir, int pc, bh_opcode opcode, bh_view& out, bh_view& in1);
@@ -136,10 +137,11 @@ public:
      */
     int expand_sign(bh_ir& bhir, int pc);
 
-
     int expand_powk(bh_ir& bhir, int pc);
 
     int expand_reduce1d(bh_ir& bhir, int pc, int fold_limit);
+
+    int expand_repeat(bh_ir& bhir, int pc);
 
 private:
 
@@ -150,6 +152,7 @@ private:
     int sign_;
     int powk_;
     int reduce1d_;
+    int repeat_;
 
 };
 
@@ -160,6 +163,11 @@ void Expander::inject(bh_ir& bhir, int pc, bh_opcode opcode, bh_view& out, bh_vi
     instr.operand[0] = out;
     instr.operand[1] = in1;
     instr.operand[2] = in2;
+    bhir.instr_list.insert(bhir.instr_list.begin()+pc, instr);
+}
+
+inline void Expander::inject(bh_ir& bhir, int pc, bh_instruction instr)
+{
     bhir.instr_list.insert(bhir.instr_list.begin()+pc, instr);
 }
 

--- a/package/debian/build-package.py
+++ b/package/debian/build-package.py
@@ -16,13 +16,13 @@ Source: bohrium
 Section: devel
 Priority: optional
 Maintainer: Bohrium Builder <builder@bh107.org>
-Build-Depends: python-numpy, debhelper, cmake, swig, python-cheetah, python-dev, fftw3-dev, cython, ocl-icd-opencl-dev, libgl-dev, libboost-serialization-dev, libboost-system-dev, libboost-filesystem-dev, libboost-thread-dev, mono-devel, mono-gmcs, libhwloc-dev, freeglut3-dev, libxmu-dev, libxi-dev, zlib1g-dev
+Build-Depends: python-numpy, debhelper, cmake, swig, python-cheetah, python-dev, fftw3-dev, cython, ocl-icd-opencl-dev, libgl-dev, libboost-serialization-dev, libboost-system-dev, libboost-filesystem-dev, libboost-thread-dev, libboost-regex-dev, mono-devel, mono-gmcs, libhwloc-dev, freeglut3-dev, libxmu-dev, libxi-dev, zlib1g-dev
 Standards-Version: 3.9.5
 Homepage: http://www.bh107.org
 
 Package: bohrium
 Architecture: amd64
-Depends: build-essential, libboost-dev, python (>= 2.7), python-numpy (>= 1.6), fftw3, libboost-serialization-dev, libboost-system-dev, libboost-filesystem-dev, libboost-thread-dev, libhwloc-dev
+Depends: build-essential, libboost-dev, python (>= 2.7), python-numpy (>= 1.6), fftw3, libboost-serialization-dev, libboost-system-dev, libboost-filesystem-dev, libboost-thread-dev, libboost-regex-dev, libhwloc-dev
 Recommends:
 Suggests: bohrium-numcil, bohrium-gpu, bohrium-visualizer, ipython,
 Description:  Bohrium Runtime System: Automatic Vector Parallelization in C, C++, CIL, and Python
@@ -265,4 +265,3 @@ if __name__ == "__main__":
 
     print "output dir: ", args.output
     main(args)
-

--- a/package/docker/ubuntu14.04/base.dockerfile
+++ b/package/docker/ubuntu14.04/base.dockerfile
@@ -16,7 +16,7 @@ ENV DEBIAN_FRONTEND noninteractive
 RUN apt-get update
 RUN apt-get install -qq wget unzip build-essential
 RUN apt-get install -qq cmake swig python python-numpy python-cheetah python-dev cython
-RUN apt-get install -qq libboost-serialization-dev libboost-system-dev libboost-filesystem-dev libboost-thread-dev
+RUN apt-get install -qq libboost-serialization-dev libboost-system-dev libboost-filesystem-dev libboost-thread-dev libboost-regex-dev
 RUN apt-get install -qq mono-mcs mono-xbuild libmono-system-numerics4.0-cil libmono-microsoft-build-tasks-v4.0-4.0-cil
 RUN apt-get install -qq fftw3-dev
 RUN apt-get install -qq libhwloc-dev

--- a/test/python/test_bohrium.py
+++ b/test/python/test_bohrium.py
@@ -3,7 +3,10 @@ import bohrium as bh
 from numpytest import numpytest,gen_views,TYPES
 
 class test_bohrium(numpytest):
-
+    def __init__(self):
+        numpytest.__init__(self)
+        self.config['maxerror'] = 0.00001
+        
     def init(self):
         for v in gen_views(1,2):
             a = {}
@@ -17,3 +20,7 @@ class test_bohrium(numpytest):
             bh.target.tally()
         return (res,cmd)
 
+    def test_repeat(self, a):
+        cmd = "a[0] += 1; a[0] += 1; res = a[0]"
+        exec(cmd)
+        return (res,cmd)

--- a/ve/cpu/autogen/tac/operations.json
+++ b/ve/cpu/autogen/tac/operations.json
@@ -8,7 +8,7 @@
         "KP_ABSOLUTE",
         "KP_INVERT",
         "KP_LOGICAL_NOT",
-        "KP_SQRT", 
+        "KP_SQRT",
         "KP_REAL",
         "KP_IMAG",
         "KP_RINT",
@@ -16,7 +16,7 @@
         "KP_ISNAN",
         "KP_CEIL",
         "KP_FLOOR",
-        "KP_TRUNC",                
+        "KP_TRUNC",
         "KP_COS",
         "KP_COSH",
         "KP_SIN",
@@ -28,11 +28,11 @@
         "KP_ARCSIN",
         "KP_ARCSINH",
         "KP_ARCTAN",
-        "KP_ARCTANH",         
+        "KP_ARCTANH",
         "KP_LOG",
         "KP_LOG10",
         "KP_LOG1P",
-        "KP_LOG2", 
+        "KP_LOG2",
         "KP_EXP",
         "KP_EXP2",
         "KP_EXPM1"
@@ -82,7 +82,7 @@
         "KP_ADD",
         "KP_MULTIPLY",
         "KP_MINIMUM",
-        "KP_MAXIMUM", 
+        "KP_MAXIMUM",
         "KP_LOGICAL_AND",
         "KP_LOGICAL_OR",
         "KP_LOGICAL_XOR",
@@ -102,7 +102,7 @@
         "KP_ADD",
         "KP_MULTIPLY",
         "KP_MINIMUM",
-        "KP_MAXIMUM", 
+        "KP_MAXIMUM",
         "KP_LOGICAL_AND",
         "KP_LOGICAL_OR",
         "KP_LOGICAL_XOR",
@@ -158,7 +158,8 @@
         "KP_FREE",
         "KP_DISCARD",
         "KP_SYNC",
-        "KP_TALLY"
+        "KP_TALLY",
+        "KP_REPEAT"
     ]
 },
 
@@ -181,4 +182,3 @@
 }
 
 ]
-

--- a/ve/cpu/autogen/tac/operators.json
+++ b/ve/cpu/autogen/tac/operators.json
@@ -65,10 +65,11 @@
     {"id": 62, "name": "KP_SYNC",      "nop": 1, "types": []},
     {"id": 63, "name": "KP_TALLY",     "nop": 0, "types": []},
     {"id": 64, "name": "KP_NONE",      "nop": 0, "types": []},
+    {"id": 65, "name": "KP_REPEAT",      "nop": 0, "types": []},
 
-    {"id": 65, "name": "KP_FLOOD",     "nop": 1, "types": []},
-    {"id": 66, "name": "KP_RANDOM",    "nop": 2, "types": []},
-    {"id": 67, "name": "KP_RANGE",     "nop": 0, "types": []},
+    {"id": 66, "name": "KP_FLOOD",     "nop": 1, "types": []},
+    {"id": 67, "name": "KP_RANDOM",    "nop": 2, "types": []},
+    {"id": 68, "name": "KP_RANGE",     "nop": 0, "types": []},
 
-    {"id": 68, "name": "KP_EXTENSION_OPERATOR","nop": 0, "types": []}
+    {"id": 69, "name": "KP_EXTENSION_OPERATOR","nop": 0, "types": []}
 ]

--- a/ve/cpu/codegen/walker_oper.cpp
+++ b/ve/cpu/codegen/walker_oper.cpp
@@ -234,6 +234,7 @@ string Walker::oper(KP_OPERATOR oper, KP_ETYPE etype, string in1, string in2)
                 case KP_FLOAT32:       return _crealf(in1);
                 default:            return _creal(in1);
             }
+        case KP_REPEAT:                break;
         case KP_RIGHT_SHIFT:           return _bitw_rightshift(in1, in2);
         case KP_RINT:                  return _rint(in1);
         case KP_SIN:

--- a/ve/cpu/kp_utils.c
+++ b/ve/cpu/kp_utils.c
@@ -66,6 +66,7 @@ size_t kp_tac_noperands(const kp_tac* tac)
                     return 1;
                 case KP_NONE:
                 case KP_TALLY:
+                case KP_REPEAT:
                     return 0;
                 default:
                     fprintf(stderr, "kp_tac_noperands: Unknown #operands of KP_SYSTEM, assuming 0;\n");

--- a/ve/cpu/tools/Makefile
+++ b/ve/cpu/tools/Makefile
@@ -36,19 +36,19 @@ release_on:
 	$(eval BUILD_OPTIONS := $(BUILD_OPTIONS) -DCMAKE_BUILD_TYPE=Release)
 
 cil_off:
-	$(eval BUILD_OPTIONS := $(BUILD_OPTIONS) -DBENCHMARK_CIL=OFF -DBRIDGE_CIL=OFF -DTEST_CIL=OFF -DBRIDGE_NUMCIL=OFF )
+	$(eval BUILD_OPTIONS := $(BUILD_OPTIONS) -DBENCHMARK_CIL=OFF -DBRIDGE_CIL=OFF -DTEST_CIL=OFF -DBRIDGE_NUMCIL=OFF)
 
 cluster_off:
-	$(eval BUILD_OPTIONS := $(BUILD_OPTIONS) -DVEM_CLUSTER=OFF -DVEM_PROXY=OFF )
+	$(eval BUILD_OPTIONS := $(BUILD_OPTIONS) -DVEM_CLUSTER=OFF -DVEM_PROXY=OFF)
 
 fun_off:
-	$(eval BUILD_OPTIONS := $(BUILD_OPTIONS) -DEXT_VISUALIZER=OFF )
+	$(eval BUILD_OPTIONS := $(BUILD_OPTIONS) -DEXT_VISUALIZER=OFF)
 
 gpu_off:
-	$(eval BUILD_OPTIONS := $(BUILD_OPTIONS) -DVE_GPU=OFF )
+	$(eval BUILD_OPTIONS := $(BUILD_OPTIONS) -DVE_GPU=OFF)
 
 cpu_debug_on:
-	$(eval BUILD_OPTIONS := $(BUILD_OPTIONS) -DVE_CPU_DEBUGGING=ON)
+	$(eval BUILD_OPTIONS := $(BUILD_OPTIONS) -DVE_CPU_DEBUGGING=ON -DCMAKE_BUILD_TYPE=Debug)
 
 cpu_profiling_on:
 	$(eval BUILD_OPTIONS := $(BUILD_OPTIONS) -DVE_CPU_PROFILING=ON)
@@ -94,7 +94,7 @@ purge_cpu: purge_ko ## Remove installed stuff specific to the CPU-engine
 	@echo "${BLUE}Removing installed stuff specific to the CPU-engine${NC}"
 	rm -rf ~/.local/share/bohrium/templates/*
 	rm -rf ~/.local/var/bohrium/scripts
-	rm -f ~/.local/lib/libbh_ve_cpu.*
+	rm -rf ~/.local/lib/libbh_ve_cpu.*
 
 
 purge_all: purge_cpu ## Remove everything (this also does 'git clean' and removes ~/.local)
@@ -108,7 +108,6 @@ purge_all: purge_cpu ## Remove everything (this also does 'git clean' and remove
 	rm -rf ~/.local/lib
 	rm -rf ~/.local/share/bohrium
 	rm -rf ~/.local/var
-	rm -f ~/.bohrium/config.ini
 
 
 reset: purge_all clean ## Purge and clean


### PR DESCRIPTION
A new instruction is introduced: `BH_REPEAT`

The `BH_REPEAT` instruction has one argument, a constant `BH_R123`. This is because we want to capture two constant values, namely how many instructions should be repeated, and how many times.

`BH_REPEAT {start: 2, key: 3}` means "repeat the next 2 instrucitons 3 times". 

In this pull-request we find repeats in the byte-code sequence (with the `find_repeats` filter) and then unravel them again (with the `expand_repeat` filter).

---

Of course at the moment, the `BH_REPEAT` doesn't do much, and thus you will need to enable both the contraction filter and the expansion filter, in order to escape segmentation faults.