### PR TITLE
Clean up filters

### DIFF
--- a/filter/bccon/CMakeLists.txt
+++ b/filter/bccon/CMakeLists.txt
@@ -11,6 +11,6 @@ file(GLOB SRC *.cpp)
 
 add_library(bh_filter_bccon SHARED ${SRC})
 
-target_link_libraries(bh_filter_bccon bh)  # We depend on bh.so
+target_link_libraries(bh_filter_bccon bh) # We depend on bh.so
 
 install(TARGETS bh_filter_bccon DESTINATION ${CMAKE_INSTALL_LIBDIR} COMPONENT bohrium)

--- a/filter/bccon/collect_filter.hpp
+++ b/filter/bccon/collect_filter.hpp
@@ -1,1 +1,0 @@
-void collect_filter(bh_ir &bhir);

--- a/filter/bccon/component_interface.cpp
+++ b/filter/bccon/component_interface.cpp
@@ -31,10 +31,7 @@ If not, see <http://www.gnu.org/licenses/>.
 //
 // Components
 //
-
-static bh_component myself; // Myself
-
-// Function pointers to our child.
+static bh_component myself;
 static bh_component_iface *child;
 
 static bool find_repeats_, reduction_, stupidmath_, collect_;

--- a/filter/bccon/contract_collect.cpp
+++ b/filter/bccon/contract_collect.cpp
@@ -17,25 +17,29 @@ GNU Lesser General Public License along with Bohrium.
 
 If not, see <http://www.gnu.org/licenses/>.
 */
+#include "contracter.hpp"
 
-#include <stdio.h>
 #include <set>
 
 #include <bh_component.h>
 
 using namespace std;
 
-bool is_add_sub(bh_opcode opc)
+namespace bohrium {
+namespace filter {
+namespace composite {
+
+static inline bool is_add_sub(bh_opcode opc)
 {
     return opc == BH_ADD or opc == BH_SUBTRACT;
 }
 
-bool is_mul_div(bh_opcode opc)
+static inline bool is_mul_div(bh_opcode opc)
 {
     return opc == BH_MULTIPLY or opc == BH_DIVIDE;
 }
 
-bool chain_has_same_type(vector<bh_instruction*>& chain)
+static bool chain_has_same_type(vector<bh_instruction*>& chain)
 {
     bh_type type = chain.front()->constant.type;
     for(vector<bh_instruction*>::iterator ite=chain.begin()+1; ite != chain.end(); ++ite) {
@@ -45,7 +49,7 @@ bool chain_has_same_type(vector<bh_instruction*>& chain)
     return true;
 }
 
-void rewrite_chain_add_sub(vector<bh_instruction*>& chain)
+static void rewrite_chain_add_sub(vector<bh_instruction*>& chain)
 {
     bh_instruction& first = *chain.front();
     bh_instruction& last = *chain.back();
@@ -99,7 +103,7 @@ void rewrite_chain_add_sub(vector<bh_instruction*>& chain)
     first.constant.set_double(sum);
 }
 
-void rewrite_chain_mul_div(vector<bh_instruction*>& chain)
+static void rewrite_chain_mul_div(vector<bh_instruction*>& chain)
 {
     bh_instruction& first = *chain.front();
     bh_instruction& last = *chain.back();
@@ -144,7 +148,7 @@ void rewrite_chain_mul_div(vector<bh_instruction*>& chain)
     first.constant.set_double(result);
 }
 
-void rewrite_chain(vector<bh_instruction*>& chain)
+static void rewrite_chain(vector<bh_instruction*>& chain)
 {
     bh_opcode opc = chain[0]->opcode;
     if (is_add_sub(opc)) {
@@ -154,7 +158,7 @@ void rewrite_chain(vector<bh_instruction*>& chain)
     }
 }
 
-void collect_filter(bh_ir &bhir)
+void Contracter::contract_collect(bh_ir &bhir)
 {
     bh_opcode collect_opcode = BH_NONE;
     vector<bh_view*> views;
@@ -219,3 +223,5 @@ void collect_filter(bh_ir &bhir)
         views.clear();
     }
 }
+
+}}}

--- a/filter/bccon/contract_reduction.cpp
+++ b/filter/bccon/contract_reduction.cpp
@@ -17,14 +17,19 @@ GNU Lesser General Public License along with Bohrium.
 
 If not, see <http://www.gnu.org/licenses/>.
 */
-#include <stdio.h>
+#include "contracter.hpp"
+
 #include <set>
 
 #include <bh_component.h>
 
 using namespace std;
 
-void rewrite_chain(vector<bh_instruction*>& links, bh_instruction* first, bh_instruction* last)
+namespace bohrium {
+namespace filter {
+namespace composite {
+
+static void rewrite_chain(vector<bh_instruction*>& links, bh_instruction* first, bh_instruction* last)
 {
     // Rewrite the first reduction as a "COMPLETE" REDUCE.
     // Copy the meta-data of the SCALAR output from the last REDUCE
@@ -42,7 +47,7 @@ void rewrite_chain(vector<bh_instruction*>& links, bh_instruction* first, bh_ins
     }
 }
 
-void reduction_chain_filter(bh_ir &bhir)
+void Contracter::contract_reduction(bh_ir &bhir)
 {
     bh_opcode reduce_opcode = BH_NONE;
     bh_instruction* first;
@@ -112,3 +117,5 @@ void reduction_chain_filter(bh_ir &bhir)
         }
     }
 }
+
+}}}

--- a/filter/bccon/contract_repeats.cpp
+++ b/filter/bccon/contract_repeats.cpp
@@ -17,6 +17,7 @@ GNU Lesser General Public License along with Bohrium.
 
 If not, see <http://www.gnu.org/licenses/>.
 */
+#include "contracter.hpp"
 
 #include <boost/regex.hpp>
 #include <iostream>
@@ -27,13 +28,17 @@ If not, see <http://www.gnu.org/licenses/>.
 
 using namespace std;
 
+namespace bohrium {
+namespace filter {
+namespace composite {
+
 // Regex matcher. This regex will match all repeating groups in a string
 // ie. will match 'bc' in 'abcbcbcde'
 static const boost::regex re("(.+)\\1+");
 
 // Convert the instruction list to a string of characters
 // Identical instructions will be mapped to the same character
-string bh_instr_list_to_string(const vector<bh_instruction> &instr_list, unordered_map<char, const bh_instruction*> &identifier_map)
+static string bh_instr_list_to_string(const vector<bh_instruction> &instr_list, unordered_map<char, const bh_instruction*> &identifier_map)
 {
     string result = "";
     char identifier = (char)((int) 'a' - 1);
@@ -63,7 +68,7 @@ string bh_instr_list_to_string(const vector<bh_instruction> &instr_list, unorder
 }
 
 // Count occurrences of str2 in str1
-int count_occur(string str1, string str2)
+static int count_occur(string str1, string str2)
 {
     int occur = 0;
     int start = 0;
@@ -76,7 +81,7 @@ int count_occur(string str1, string str2)
     return occur;
 }
 
-void find_repeats_filter(bh_ir &bhir)
+void Contracter::contract_repeats(bh_ir &bhir)
 {
     // Build map of instructions and string representation of instruction list
     unordered_map<char, const bh_instruction*> identifier_map;
@@ -133,3 +138,5 @@ void find_repeats_filter(bh_ir &bhir)
 
     return;
 }
+
+}}}

--- a/filter/bccon/contract_stupidmath.cpp
+++ b/filter/bccon/contract_stupidmath.cpp
@@ -17,14 +17,19 @@ GNU Lesser General Public License along with Bohrium.
 
 If not, see <http://www.gnu.org/licenses/>.
 */
-#include <stdio.h>
+#include "contracter.hpp"
+
 #include <set>
 
 #include <bh_component.h>
 
 using namespace std;
 
-bool bh_constant_is_value(bh_constant constant, float_t value)
+namespace bohrium {
+namespace filter {
+namespace composite {
+
+static bool bh_constant_is_value(bh_constant constant, float_t value)
 {
     switch(constant.type) {
         case BH_UINT8:
@@ -58,41 +63,41 @@ bool bh_constant_is_value(bh_constant constant, float_t value)
     }
 }
 
-bool is_multiplying_by_one(bh_instruction& instr)
+static inline bool is_multiplying_by_one(bh_instruction& instr)
 {
     return instr.opcode == BH_MULTIPLY and
            bh_is_constant(&(instr.operand[2])) and
            bh_constant_is_value(instr.constant, 1.0);
 }
 
-bool is_dividing_by_one(bh_instruction& instr)
+static inline bool is_dividing_by_one(bh_instruction& instr)
 {
     return instr.opcode == BH_DIVIDE and
            bh_is_constant(&(instr.operand[2])) and
            bh_constant_is_value(instr.constant, 1.0);
 }
 
-bool is_adding_zero(bh_instruction& instr)
+static inline bool is_adding_zero(bh_instruction& instr)
 {
     return instr.opcode == BH_ADD and
            bh_is_constant(&(instr.operand[2])) and
            bh_constant_is_value(instr.constant, 0.0);
 }
 
-bool is_subtracting_zero(bh_instruction& instr)
+static inline bool is_subtracting_zero(bh_instruction& instr)
 {
     return instr.opcode == BH_SUBTRACT and
            bh_is_constant(&(instr.operand[2])) and
            bh_constant_is_value(instr.constant, 0.0);
 }
 
-bool is_free_or_discard(bh_instruction& instr)
+static inline bool is_free_or_discard(bh_instruction& instr)
 {
     return instr.opcode == BH_FREE or
            instr.opcode == BH_DISCARD;
 }
 
-bool is_doing_stupid_math(bh_instruction& instr)
+static inline bool is_doing_stupid_math(bh_instruction& instr)
 {
     return is_multiplying_by_one(instr) or
            is_dividing_by_one(instr) or
@@ -100,7 +105,7 @@ bool is_doing_stupid_math(bh_instruction& instr)
            is_subtracting_zero(instr);
 }
 
-void stupid_math_filter(bh_ir &bhir)
+void Contracter::contract_stupidmath(bh_ir &bhir)
 {
     for(size_t pc = 0; pc < bhir.instr_list.size(); ++pc) {
         bh_instruction& instr = bhir.instr_list[pc];
@@ -162,3 +167,5 @@ void stupid_math_filter(bh_ir &bhir)
         }
     }
 }
+
+}}}

--- a/filter/bccon/contracter.cpp
+++ b/filter/bccon/contracter.cpp
@@ -1,0 +1,41 @@
+/*
+This file is part of Bohrium and copyright (c) 2012 the Bohrium
+team <http://www.bh107.org>.
+
+Bohrium is free software: you can redistribute it and/or modify
+it under the terms of the GNU Lesser General Public License as
+published by the Free Software Foundation, either version 3
+of the License, or (at your option) any later version.
+
+Bohrium is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the
+GNU Lesser General Public License along with Bohrium.
+
+If not, see <http://www.gnu.org/licenses/>.
+*/
+#include "contracter.hpp"
+
+using namespace std;
+
+namespace bohrium {
+namespace filter {
+namespace composite {
+
+Contracter::Contracter(bool repeats, bool reduction, bool stupidmath, bool collect)
+    : repeats_(repeats), reduction_(reduction), stupidmath_(stupidmath), collect_(collect) {}
+
+Contracter::~Contracter(void) {}
+
+void Contracter::contract(bh_ir& bhir)
+{
+    if(repeats_)    contract_repeats(bhir);
+    if(reduction_)  contract_reduction(bhir);
+    if(stupidmath_) contract_stupidmath(bhir);
+    if(collect_)    contract_collect(bhir);
+}
+
+}}}

--- a/filter/bccon/contracter.hpp
+++ b/filter/bccon/contracter.hpp
@@ -1,0 +1,32 @@
+#ifndef __BH_FILTER_COMPOSITE_CONTRACTER
+#define __BH_FILTER_COMPOSITE_CONTRACTER
+
+#include <bh_component.h>
+
+namespace bohrium {
+namespace filter {
+namespace composite {
+
+class Contracter
+{
+public:
+    Contracter(bool repeats, bool reduction, bool stupidmath, bool collect);
+
+    ~Contracter(void);
+
+    void contract(bh_ir& bhir);
+
+    void contract_repeats(bh_ir& bhir);
+    void contract_reduction(bh_ir& bhir);
+    void contract_stupidmath(bh_ir& bhir);
+    void contract_collect(bh_ir& bhir);
+
+private:
+    bool repeats_;
+    bool reduction_;
+    bool stupidmath_;
+    bool collect_;
+};
+
+}}}
+#endif

--- a/filter/bccon/find_repeats_filter.hpp
+++ b/filter/bccon/find_repeats_filter.hpp
@@ -1,1 +1,0 @@
-void find_repeats_filter(bh_ir &bhir);

--- a/filter/bccon/reduction_chain_filter.hpp
+++ b/filter/bccon/reduction_chain_filter.hpp
@@ -1,1 +1,0 @@
-void reduction_chain_filter(bh_ir &bhir);

--- a/filter/bccon/stupid_math_filter.hpp
+++ b/filter/bccon/stupid_math_filter.hpp
@@ -1,1 +1,0 @@
-void stupid_math_filter(bh_ir &bhir);

--- a/filter/bcexp/CMakeLists.txt
+++ b/filter/bcexp/CMakeLists.txt
@@ -11,6 +11,6 @@ file(GLOB SRC *.cpp)
 
 add_library(bh_filter_bcexp SHARED ${SRC})
 
-target_link_libraries(bh_filter_bcexp bh)    #We depend on bh.so
+target_link_libraries(bh_filter_bcexp bh) # We depend on bh.so
 
 install(TARGETS bh_filter_bcexp DESTINATION ${CMAKE_INSTALL_LIBDIR} COMPONENT bohrium)

--- a/filter/bcexp/component_interface.cpp
+++ b/filter/bcexp/component_interface.cpp
@@ -65,30 +65,21 @@ bh_error bh_filter_bcexp_init(const char* name)
         return err;
     }
 
-    bh_intp gc_threshold, sign, matmul, powk, repeat, reduce1d;
-    if ((BH_SUCCESS!=bh_component_config_int_option(&myself, "gc_threshold", 0, 2000, &gc_threshold)) or \
-        (BH_SUCCESS!=bh_component_config_int_option(&myself, "matmul", 0, 1, &matmul)) or \
-        (BH_SUCCESS!=bh_component_config_int_option(&myself, "sign", 0, 1, &sign)) or \
-        (BH_SUCCESS!=bh_component_config_int_option(&myself, "powk", 0, 1, &powk)) or \
-        (BH_SUCCESS!=bh_component_config_int_option(&myself, "repeat", 0, 1, &repeat))) {
-        return BH_ERROR;
-    }
-    reduce1d = bh_component_config_lookup_int(&myself, "reduce1d", 0);
     try {                           // Construct the expander
-        expander = new bohrium::filter::composite::Expander(gc_threshold,
-                                                            matmul,
-                                                            sign,
-                                                            powk,
-                                                            reduce1d,
-                                                            repeat);
+        expander = new bohrium::filter::composite::Expander(
+            bh_component_config_lookup_int( &myself, "gc_threshold",  400),
+            bh_component_config_lookup_bool(&myself, "matmul",       true),
+            bh_component_config_lookup_bool(&myself, "sign",         true),
+            bh_component_config_lookup_bool(&myself, "powk",         true),
+            bh_component_config_lookup_bool(&myself, "reduce1d",    false),
+            bh_component_config_lookup_bool(&myself, "repeat",       true)
+        );
     } catch (std::bad_alloc& ba) {
         fprintf(stderr, "Failed constructing Expander due to allocation error.\n");
-    }
-    if (NULL == expander) {
         return BH_ERROR;
-    } else {
-        return BH_SUCCESS;
     }
+
+    return BH_SUCCESS;
 }
 
 bh_error bh_filter_bcexp_shutdown(void)

--- a/filter/bcexp/component_interface.cpp
+++ b/filter/bcexp/component_interface.cpp
@@ -32,7 +32,7 @@ If not, see <http://www.gnu.org/licenses/>.
 static bh_component myself;         // Myself
 static bh_component_iface *child;   // My child
 
-//The timing ID for the filter
+// The timing ID for the filter
 static bh_intp exec_timing;
 static bool timing;
 

--- a/filter/bcexp/expand_matmul.cpp
+++ b/filter/bcexp/expand_matmul.cpp
@@ -25,53 +25,75 @@ namespace bohrium {
 namespace filter {
 namespace composite {
 
+/**
+ *  Expand matmul at the given pc in the bhir instruction list.
+ *
+ *  Returns the number of additional instructions used.
+ */
 int Expander::expand_matmul(bh_ir& bhir, int pc)
 {
     int start_pc = pc;
     bh_instruction& composite = bhir.instr_list[pc];
-    composite.opcode = BH_NONE;                     // Lazy choice... no re-use just NOP it.
 
-    bh_view out = composite.operand[0];             // Grab operands
-    bh_view a = composite.operand[1];
-    bh_view b = composite.operand[2];
+    // Lazy choice... no re-use just NOP it.
+    composite.opcode = BH_NONE;
 
-    int n = a.shape[0];                             // Grab the shape
+    // Grab operands
+    bh_view out = composite.operand[0];
+    bh_view a   = composite.operand[1];
+    bh_view b   = composite.operand[2];
+
+    // Grab the shape
+    int n = a.shape[0];
     int m = a.shape[1];
     int k = b.shape[1];
-                                                    // Construct intermediary operands
-    bh_view a_3d = a;                               // Needs broadcast
-    bh_view b_3d = b;                               // Needs transposition + broadcast
+
+    // Construct intermediary operands
+    // Needs broadcast
+    bh_view a_3d = a;
+
+    // Needs transposition + broadcast
+    bh_view b_3d = b;
 
     a_3d.ndim = 3;
     b_3d.ndim = 3;
-    a_3d.shape[0] = b_3d.shape[0] = n;               // Set the shape
+
+    // Set the shape
+    a_3d.shape[0] = b_3d.shape[0] = n;
     a_3d.shape[1] = b_3d.shape[1] = k;
     a_3d.shape[2] = b_3d.shape[2] = m;
 
-    a_3d.stride[0] = a.stride[0];                   // Construct broadcast
+    // Construct broadcast
+    a_3d.stride[0] = a.stride[0];
     a_3d.stride[1] = 0;
     a_3d.stride[2] = a.stride[1];
 
-    b_3d.stride[0] = 0;                             // Construct transpose + broadcast
+    // Construct transpose + broadcast
+    b_3d.stride[0] = 0;
     b_3d.stride[1] = b.stride[1];
     b_3d.stride[2] = b.stride[0];
 
-    bh_view c_3d = b_3d;                            // Construct temp for mul-result
-    bh_intp nelements = 1;                          // Count number of elements
-    for(bh_intp dim=c_3d.ndim-1; dim >= 0; --dim) { // Set contiguous stride
+    // Construct temp for mul-result
+    bh_view c_3d = b_3d;
+
+    // Count number of elements
+    bh_intp nelements = 1;
+
+    // Set contiguous stride
+    for(bh_intp dim=c_3d.ndim-1; dim >= 0; --dim) {
         c_3d.stride[dim] = nelements;
         nelements *= c_3d.shape[dim];
     }
-    c_3d.start = 0;                                 
+    c_3d.start = 0;
     c_3d.base = make_base(b_3d.base->type, nelements);
 
-                                                    // Expand sequence
-    inject(bhir, ++pc, BH_MULTIPLY, c_3d, a_3d, b_3d);
-    inject(bhir, ++pc, BH_ADD_REDUCE, out, c_3d, (int64_t)2, BH_INT64);
-    inject(bhir, ++pc, BH_FREE, c_3d);
-    inject(bhir, ++pc, BH_DISCARD, c_3d);
+    // Expand sequence
+    inject(bhir, ++pc, BH_MULTIPLY,   c_3d, a_3d, b_3d);
+    inject(bhir, ++pc, BH_ADD_REDUCE, out,  c_3d, (int64_t)2, BH_INT64);
+    inject(bhir, ++pc, BH_FREE,       c_3d);
+    inject(bhir, ++pc, BH_DISCARD,    c_3d);
 
-    return pc-start_pc;
+    return pc - start_pc;
 }
 
 }}}

--- a/filter/bcexp/expand_repeat.cpp
+++ b/filter/bcexp/expand_repeat.cpp
@@ -18,7 +18,6 @@ GNU Lesser General Public License along with Bohrium.
 If not, see <http://www.gnu.org/licenses/>.
 */
 #include "expander.hpp"
-#include <math.h>
 
 using namespace std;
 

--- a/filter/bcexp/expander.cpp
+++ b/filter/bcexp/expander.cpp
@@ -25,8 +25,6 @@ namespace bohrium {
 namespace filter {
 namespace composite {
 
-const char Expander::TAG[] = "Expander";
-
 Expander::Expander(size_t threshold, int matmul, int sign, int powk, int reduce1d, int repeat)
     : gc_threshold_(threshold), matmul_(matmul), sign_(sign), powk_(powk), reduce1d_(reduce1d), repeat_(repeat){}
 

--- a/filter/bcexp/expander.hpp
+++ b/filter/bcexp/expander.hpp
@@ -68,7 +68,6 @@ public:
     template <typename T>
     inline void inject(bh_ir& bhir, int pc, bh_opcode opcode, bh_view& out, T in1);
 
-
     // Binary instruction
     inline void inject(bh_ir& bhir, int pc, bh_opcode opcode, bh_view& out, bh_view& in1, bh_view& in2);
     // Binary with constants
@@ -78,73 +77,13 @@ public:
     template <typename T>
     inline void inject(bh_ir& bhir, int pc, bh_opcode opcode, bh_view& out, bh_view& in1, T in2);
 
-    /**
-     *  Expand matmul at the given pc in the bhir instruction list.
-     *
-     *  Returns the number of additional instructions used.
-     */
     int expand_matmul(bh_ir& bhir, int pc);
-
-    /**
-     *  Expand BH_SIGN at the given PC into the sequence:
-     *
-     *          BH_SIGN OUT, IN1 (When IN1.type != COMPLEX):
-     *
-     *  LESS, t1_bool, input, 0.0
-     *  IDENTITY, t1, t1_bool
-     *  FREE, t1_bool
-     *  DISCARD, t1_bool
-     *
-     *  GREATER, t2_bool, input, 0.0
-     *  IDENTITY, t2, t2_bool
-     *  FREE, t2_bool
-     *  DISCARD, t2_bool
-     *
-     *  SUBTRACT, out, t2, t1
-     *  FREE, t1
-     *  DISCARD, t1
-     *  FREE, t2
-     *  DISCARD, t2
-     *
-     *          BH_SIGN OUT, IN1 (When IN1.type == COMPLEX):
-     *
-     *  REAL, input_r, input
-     *
-     *  LESS, t1_bool, input_r, 0.0
-     *  IDENTITY, t1, t1_bool
-     *  FREE, t1_bool
-     *  DISCARD, t1_bool
-     *
-     *  GREATER, t2_bool, input_r, 0.0
-     *  FREE, input_r
-     *  DISCARD, input_r
-     *
-     *  IDENTITY, t2, t2_bool
-     *  FREE, t2_bool
-     *  DISCARD, t2_bool
-     *
-     *  SUBTRACT, t3, t2, t1
-     *  FREE, t1
-     *  DISCARD, t1
-     *  FREE, t2
-     *  DISCARD, t2
-     *
-     *  IDENTITY, out, t3
-     *  FREE, t3
-     *  DISCARD, t3
-     *
-     *  Returns the number of instructions used (12 or 17).
-     */
     int expand_sign(bh_ir& bhir, int pc);
-
     int expand_powk(bh_ir& bhir, int pc);
-
     int expand_reduce1d(bh_ir& bhir, int pc, int fold_limit);
-
     int expand_repeat(bh_ir& bhir, int pc);
 
 private:
-
     static const char TAG[];
     std::vector<bh_base*> bases_;
     size_t gc_threshold_;
@@ -153,7 +92,6 @@ private:
     int powk_;
     int reduce1d_;
     int repeat_;
-
 };
 
 void Expander::inject(bh_ir& bhir, int pc, bh_opcode opcode, bh_view& out, bh_view& in1, bh_view& in2)


### PR DESCRIPTION
This pull-request creates a new class `Contracter`, which works just like the `Expander` for the expand filters.

A new naming convention is put into place for the filters (start with `contract_` or `expand_`)

A lot of comments have been moved around (but not deleted)