### PR TITLE
[docker] Update Python, Cython and NumPy

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,8 +9,8 @@ compiler:
   - gcc
 
 before_install:
-  - docker pull bohrium/ubuntu:14.04
-  - docker build -t bohrium_release -f package/docker/ubuntu14.04/bohrium.dockerfile .
+  - docker pull bohrium/ubuntu:16.04
+  - docker build -t bohrium_release -f package/docker/bohrium.dockerfile .
 
 env:
   global:

--- a/package/docker/base.dockerfile
+++ b/package/docker/base.dockerfile
@@ -1,6 +1,6 @@
 # This is a Dockerfile for installing Bohrium dependencies
 
-FROM ubuntu:14.04
+FROM ubuntu:16.04
 MAINTAINER Mads R. B. Kristensen <madsbk@gmail.com>
 RUN mkdir -p /bohrium/build
 WORKDIR /bohrium/build
@@ -40,7 +40,7 @@ RUN apt-get install -qq zlib1g-dev valgrind gdb vim cgdb
 # Build and install source dependencies
 RUN mkdir -p /opt/dython
 WORKDIR /opt/dython
-ENV PV 2.7.3
+ENV PV 2.7.11
 RUN wget -q http://www.python.org/ftp/python/$PV/Python-$PV.tgz
 RUN tar -xzf Python-$PV.tgz
 WORKDIR Python-$PV
@@ -51,7 +51,7 @@ RUN rm ../Python-$PV.tgz
 
 RUN mkdir -p /opt/cython
 WORKDIR /opt/cython
-ENV CV 0.22
+ENV CV 0.24
 RUN wget -q http://cython.org/release/Cython-$CV.tar.gz
 RUN tar -xzf Cython-$CV.tar.gz
 WORKDIR Cython-$CV
@@ -69,7 +69,7 @@ RUN rm ../Cheetah-$CTV.tar.gz
 
 RUN mkdir -p /opt/numpy
 WORKDIR /opt/numpy
-ENV NV 1.8.2
+ENV NV 1.10.4
 RUN wget -q http://optimate.dl.sourceforge.net/project/numpy/NumPy/$NV/numpy-$NV.tar.gz
 RUN tar -xzf numpy-$NV.tar.gz
 WORKDIR numpy-$NV

--- a/package/docker/bohrium.dockerfile
+++ b/package/docker/bohrium.dockerfile
@@ -4,7 +4,7 @@
 # e.g. 'docker build -t bohrium -f <path to this file> <path to bohrium source>'
 # Then you can run 'docker run -t bohrium' to Bohrium test
 
-FROM bohrium/ubuntu:14.04
+FROM bohrium/ubuntu:16.04
 MAINTAINER Mads R. B. Kristensen <madsbk@gmail.com>
 
 # Set the locale

--- a/package/docker/bohrium_debug.dockerfile
+++ b/package/docker/bohrium_debug.dockerfile
@@ -4,7 +4,7 @@
 # e.g. 'docker build -t bohrium -f <path to this file> <path to bohrium source>'
 # Then you can run 'docker run -t bohrium' to Bohrium test
 
-FROM bohrium/ubuntu:14.04
+FROM bohrium/ubuntu:16.04
 MAINTAINER Mads R. B. Kristensen <madsbk@gmail.com>
 
 # Set the locale


### PR DESCRIPTION
Updating to NumPy 1.11.0 doesn't work (won't install with `setup.py`).