### PR TITLE
Allow bare types

### DIFF
--- a/bridge/npbackend/__init__.py
+++ b/bridge/npbackend/__init__.py
@@ -28,6 +28,14 @@ asanyarray = array
 for f in UFUNCS:
     exec("%s = f" % f.info['name'])
 
+# Aliases
+aliases = [
+    ('abs', 'absolute')
+]
+
+for f, t in aliases:
+    exec("%s = %s" % (f, t))
+
 # Expose all data types
 for t in numpy_types:
     exec("%s = numpy.%s"%(t.__str__(),t.__str__()))

--- a/bridge/npbackend/__init__.py
+++ b/bridge/npbackend/__init__.py
@@ -38,7 +38,19 @@ for f, t in aliases:
 
 # Expose all data types
 for t in numpy_types:
-    exec("%s = numpy.%s"%(t.__str__(),t.__str__()))
+    exec("%s = numpy.%s" % (t.__str__(), t.__str__()))
+
+# Type aliases
+type_aliases = [
+    ('bool',    'bool'),
+    ('int',     'int'),
+    ('uint',    'numpy.uint64'),
+    ('float',   'float'),
+    ('complex', 'complex')
+]
+
+for f, t in type_aliases:
+    exec("%s = %s" % (f, t))
 
 # Note that the following modules needs ufuncs and dtypes
 from . import random123 as random

--- a/bridge/npbackend/ufunc.py
+++ b/bridge/npbackend/ufunc.py
@@ -494,14 +494,18 @@ class Sign(Ufunc):
             out[...] = (ary < 0)*ary.dtype.type(-1) + (ary>0)*ary.dtype.type(1)
             return out
 
+# Expose via UFUNCS
 UFUNCS = [
     Negative({'name':'negative'}),
     Sign({'name':'sign'})
-]    # Expose via UFUNCS
+]
+
 for op in _info.op.itervalues():
     UFUNCS.append(Ufunc(op))
 
-for ufunc in UFUNCS:                        # Expose via their name.
+# Expose via their name.
+for ufunc in UFUNCS:
     exec("%s = ufunc" % ufunc.info['name'])
 
-del ufunc # We do not want to expose a function named "ufunc"
+# We do not want to expose a function named "ufunc"
+del ufunc

--- a/core/codegen/types.json
+++ b/core/codegen/types.json
@@ -1,23 +1,22 @@
 [
-{"id": 0,   "enum": "BH_BOOL",          "size": "1",    "shorthand": "z",   "bhtype": "bh_bool",        "numpy": "bool_",         "union": "bool8",       "c": "unsigned char",   "cpp": "bool"  },
+  {"id": 0,  "enum": "BH_BOOL",       "size": "1",  "shorthand": "z", "bhtype": "bh_bool",       "numpy": "bool_",      "union": "bool8",      "c": "unsigned char",  "cpp": "bool"            },
 
-{"id": 1,   "enum": "BH_INT8",          "size": "1",    "shorthand": "b",   "bhtype": "bh_int8",        "numpy": "int8",          "union": "int8",        "c": "int8_t",          "cpp": "int8_t"         },
-{"id": 2,   "enum": "BH_INT16",         "size": "2",    "shorthand": "s",   "bhtype": "bh_int16",       "numpy": "int16",         "union": "int16",       "c": "int16_t",         "cpp": "int16_t"        },
-{"id": 3,   "enum": "BH_INT32",         "size": "4",    "shorthand": "i",   "bhtype": "bh_int32",       "numpy": "int32",         "union": "int32",       "c": "int32_t",         "cpp": "int32_t"        },
-{"id": 4,   "enum": "BH_INT64",         "size": "8",    "shorthand": "l",   "bhtype": "bh_int64",       "numpy": "int64",         "union": "int64",       "c": "int64_t",         "cpp": "int64_t"        },
+  {"id": 1,  "enum": "BH_INT8",       "size": "1",  "shorthand": "b", "bhtype": "bh_int8",       "numpy": "int8",       "union": "int8",       "c": "int8_t",         "cpp": "int8_t"          },
+  {"id": 2,  "enum": "BH_INT16",      "size": "2",  "shorthand": "s", "bhtype": "bh_int16",      "numpy": "int16",      "union": "int16",      "c": "int16_t",        "cpp": "int16_t"         },
+  {"id": 3,  "enum": "BH_INT32",      "size": "4",  "shorthand": "i", "bhtype": "bh_int32",      "numpy": "int32",      "union": "int32",      "c": "int32_t",        "cpp": "int32_t"         },
+  {"id": 4,  "enum": "BH_INT64",      "size": "8",  "shorthand": "l", "bhtype": "bh_int64",      "numpy": "int64",      "union": "int64",      "c": "int64_t",        "cpp": "int64_t"         },
 
-{"id": 5,   "enum": "BH_UINT8",         "size": "1",    "shorthand": "B",   "bhtype": "bh_uint8",       "numpy": "uint8",         "union": "uint8",       "c": "uint8_t",         "cpp": "uint8_t"        },
-{"id": 6,   "enum": "BH_UINT16",        "size": "2",    "shorthand": "S",   "bhtype": "bh_uint16",      "numpy": "uint16",        "union": "uint16",      "c": "uint16_t",        "cpp": "uint16_t"       },
-{"id": 7,   "enum": "BH_UINT32",        "size": "4",    "shorthand": "I",   "bhtype": "bh_uint32",      "numpy": "uint32",        "union": "uint32",      "c": "uint32_t",        "cpp": "uint32_t"       },
-{"id": 8,   "enum": "BH_UINT64",        "size": "8",    "shorthand": "L",   "bhtype": "bh_uint64",      "numpy": "uint64",        "union": "uint64",      "c": "uint64_t",        "cpp": "uint64_t"       },
+  {"id": 5,  "enum": "BH_UINT8",      "size": "1",  "shorthand": "B", "bhtype": "bh_uint8",      "numpy": "uint8",      "union": "uint8",      "c": "uint8_t",        "cpp": "uint8_t"         },
+  {"id": 6,  "enum": "BH_UINT16",     "size": "2",  "shorthand": "S", "bhtype": "bh_uint16",     "numpy": "uint16",     "union": "uint16",     "c": "uint16_t",       "cpp": "uint16_t"        },
+  {"id": 7,  "enum": "BH_UINT32",     "size": "4",  "shorthand": "I", "bhtype": "bh_uint32",     "numpy": "uint32",     "union": "uint32",     "c": "uint32_t",       "cpp": "uint32_t"        },
+  {"id": 8,  "enum": "BH_UINT64",     "size": "8",  "shorthand": "L", "bhtype": "bh_uint64",     "numpy": "uint64",     "union": "uint64",     "c": "uint64_t",       "cpp": "uint64_t"        },
 
-{"id": 9,  "enum": "BH_FLOAT32",       "size": "4",    "shorthand": "f",   "bhtype": "bh_float32",     "numpy": "float32",       "union": "float32",     "c": "float",           "cpp": "float"          },
-{"id": 10,  "enum": "BH_FLOAT64",       "size": "8",    "shorthand": "d",   "bhtype": "bh_float64",     "numpy": "float64",       "union": "float64",     "c": "double",          "cpp": "double"         },
+  {"id": 9,  "enum": "BH_FLOAT32",    "size": "4",  "shorthand": "f", "bhtype": "bh_float32",    "numpy": "float32",    "union": "float32",    "c": "float",          "cpp": "float"           },
+  {"id": 10, "enum": "BH_FLOAT64",    "size": "8",  "shorthand": "d", "bhtype": "bh_float64",    "numpy": "float64",    "union": "float64",    "c": "double",         "cpp": "double"          },
 
-{"id": 11,  "enum": "BH_COMPLEX64",     "size": "8",    "shorthand": "c",   "bhtype": "bh_complex64",   "numpy": "complex64",     "union": "complex64",   "c": "float complex",   "cpp": "complex<float>" },
-{"id": 12,  "enum": "BH_COMPLEX128",    "size": "16",   "shorthand": "C",   "bhtype": "bh_complex128",  "numpy": "complex128",    "union": "complex128",  "c": "double complex",  "cpp": "complex<double>"},
+  {"id": 11, "enum": "BH_COMPLEX64",  "size": "8",  "shorthand": "c", "bhtype": "bh_complex64",  "numpy": "complex64",  "union": "complex64",  "c": "float complex",  "cpp": "complex<float>"  },
+  {"id": 12, "enum": "BH_COMPLEX128", "size": "16", "shorthand": "C", "bhtype": "bh_complex128", "numpy": "complex128", "union": "complex128", "c": "double complex", "cpp": "complex<double>" },
 
-{"id": 13,  "enum": "BH_R123",          "size": "16",   "shorthand": "R",   "bhtype": "bh_r123",        "numpy": "unknown",        "union": "r123",  "c": "bh_r123",  "cpp": "bh_r123"},
-
-{"id": 14,  "enum": "BH_UNKNOWN",       "size": "1",    "shorthand": "U",   "bhtype":  "bh_unknown",    "numpy": "unknown",        "union": "unknown",     "c": "<UNKNOWN>",       "cpp": "<UNKNOWN>"      }
+  {"id": 13, "enum": "BH_R123",       "size": "16", "shorthand": "R", "bhtype": "bh_r123",       "numpy": "unknown",    "union": "r123",       "c": "bh_r123",        "cpp": "bh_r123"         },
+  {"id": 14, "enum": "BH_UNKNOWN",    "size": "1",  "shorthand": "U", "bhtype": "bh_unknown",    "numpy": "unknown",    "union": "unknown",    "c": "<UNKNOWN>",      "cpp": "<UNKNOWN>"       }
 ]


### PR DESCRIPTION
We now have `abs` as an alias method for `absolute`, so we can have code like #108 

Also, the built-in types (`bool`, `int`, `float`, and `complex`) which are present in NumPy are also now present to use with Bohrium. This means that the code:

```python
import numpy as np
z = np.arange(10, dtype=np.int)
print z
```

will work when doing: `python -m bohrium test.py`.

Fixes #108 