### PR TITLE
Actually run benchmark tests

### DIFF
--- a/.travis/install.sh
+++ b/.travis/install.sh
@@ -9,7 +9,9 @@ if [[ $TRAVIS_OS_NAME == "osx" ]]; then
   # Fetch 'benchpress'
   mkdir -p $HOME/benchpress
   wget -nv https://github.com/bh107/benchpress/archive/master.zip -O $HOME/benchpress/master.zip
-  unzip -q $HOME/benchpress/master.zip
+  pushd $HOME/benchpress
+  unzip -q master.zip
+  popd
 
   export PATH="$HOME/benchpress/benchpress-master/bin:$PATH"
   export DYLD_LIBRARY_PATH="/usr/lib:$HOME/.local/lib:$DYLD_LIBRARY_PATH"

--- a/.travis/run.sh
+++ b/.travis/run.sh
@@ -21,8 +21,10 @@ if [[ $TRAVIS_OS_NAME == "osx" ]]; then
       ;;
   esac
 
-  $PEXEC $TRAVIS_BUILD_DIR/test/python/run.py $TRAVIS_BUILD_DIR/test/python/tests/test_*.py
-  $PEXEC $TRAVIS_BUILD_DIR/test/python/numpytest.py --file $TRAVIS_BUILD_DIR/test/python/test_benchmarks.py
+  cd $TRAVIS_BUILD_DIR
+  bh-info
+  $PEXEC test/python/run.py test/python/tests/test_*.py
+  $PEXEC test/python/numpytest.py --file test_benchmarks.py
 else
   #############
   #   LINUX   #

--- a/test/python/numpytest.py
+++ b/test/python/numpytest.py
@@ -311,6 +311,11 @@ class BenchHelper:
         env = os.environ.copy()
         env['BH_PROXY_PORT'] = "4201"
 
+        # SIP on macOS won't allow passing on DYLD_LIBRARY_PATH in env, so
+        # we attach it to the command instead.
+        if "DYLD_LIBRARY_PATH" in env:
+            cmd = ["DYLD_LIBRARY_PATH=" + env["DYLD_LIBRARY_PATH"]] + cmd
+
         # Execute the benchmark
         out = shell_cmd(cmd, verbose=self.args.verbose, env=env)
         if 'elapsed-time' not in out:


### PR DESCRIPTION
~~`benchpress is not installed -- skipping test.`~~

After forcing `DYLD_LIBRARY_PATH` to be set, if present in the env, we now run the benchmarks on MacOS as well.