### PR TITLE
Use Jenkins ANSI colors

### DIFF
--- a/misc/bh-info
+++ b/misc/bh-info
@@ -26,11 +26,11 @@ from ConfigParser import SafeConfigParser, NoOptionError
 import subprocess
 import re
 
-HEADER  = '\033[95m'
-OKBLUE  = '\033[94m'
-OKGREEN = '\033[92m'
-WARNING = '\033[93m'
-FAIL    = '\033[91m'
+HEADER  = '\033[35m'
+OKBLUE  = '\033[34m'
+OKGREEN = '\033[32m'
+WARNING = '\033[33m'
+FAIL    = '\033[31m'
 END     = '\033[0m'
 
 def parse_config(verbose=True):

--- a/test/python/numpytest.py
+++ b/test/python/numpytest.py
@@ -35,11 +35,11 @@ class TYPES:
 
 
 class _C:
-    HEADER  = '\033[95m'
-    OKBLUE  = '\033[94m'
-    OKGREEN = '\033[92m'
-    WARNING = '\033[93m'
-    FAIL    = '\033[91m'
+    HEADER  = '\033[35m'
+    OKBLUE  = '\033[34m'
+    OKGREEN = '\033[32m'
+    WARNING = '\033[33m'
+    FAIL    = '\033[31m'
     ENDC    = '\033[0m'
 
     def disable(self):

--- a/test/python/run.py
+++ b/test/python/run.py
@@ -14,11 +14,11 @@ assert (numpy != bohrium)
 
 
 # Terminal colors
-HEADER  = '\033[95m'
-OKBLUE  = '\033[94m'
-OKGREEN = '\033[92m'
-WARNING = '\033[93m'
-FAIL    = '\033[91m'
+HEADER  = '\033[35m'
+OKBLUE  = '\033[34m'
+OKGREEN = '\033[32m'
+WARNING = '\033[33m'
+FAIL    = '\033[31m'
 ENDC    = '\033[0m'
 
 

--- a/test/python/tests/test_ext_blas.py
+++ b/test/python/tests/test_ext_blas.py
@@ -6,7 +6,7 @@ import platform
 from os import environ
 os = platform.system()
 if os == "Darwin" and environ.get("BH_STACK", "") == "opencl":
-    print("\033[91m[EXT] Ignoring 64-bit OpenCL clBLAS tests on MacOS.\n[EXT] Intel graphics does not support 64-bit float and complex types.\033[0m")
+    print("\033[31m[EXT] Ignoring 64-bit OpenCL clBLAS tests on MacOS.\n[EXT] Intel graphics does not support 64-bit float and complex types.\033[0m")
     float_types   = ['np.float32']
     complex_types = []
 else:


### PR DESCRIPTION
Jenkins doesn't understand "high-intensity" ANSI colors (e.g. `\033[94m`, which is "light-blue") instead it only recognizes normal colors, e.g. `\033[34m`, which is "blue".