### PR TITLE
Added round alias

### DIFF
--- a/bridge/npbackend/__init__.py
+++ b/bridge/npbackend/__init__.py
@@ -61,7 +61,8 @@ for _name, _f in UFUNCS.items():
 
 # Aliases
 _aliases = [
-    ('abs', 'absolute')
+    ('abs', 'absolute'),
+    ('round', 'round_')
 ]
 for _f, _t in _aliases:
     exec("%s = %s" % (_f, _t))


### PR DESCRIPTION
Fixes #259

However! We now get 

```
/usr/local/lib/python2.7/site-packages/numpy/core/fromnumeric.py:57: RuntimeWarning: Encountering an operation not supported by Bohrium. It will be handled by the original NumPy.
  return getattr(obj, method)(*args, **kwds)
```

when using `bh.round(...)`