### PR TITLE
Fail before adding extmethod to cache

### DIFF
--- a/bridge/cpp/bxx/runtime.hpp
+++ b/bridge/cpp/bxx/runtime.hpp
@@ -377,8 +377,8 @@ void Runtime::enqueue_extension(const std::string& name,
         opcode = it->second;
     } else {                        // Add it
         opcode = extension_count++;
-        extensions.insert(std::pair<std::string, bh_opcode>(name, opcode));
         runtime.extmethod(name.c_str(), opcode);
+        extensions.insert(std::pair<std::string, bh_opcode>(name, opcode));
     }
 
     guard();


### PR DESCRIPTION
Fixes #264

--- 

The problem was, that the extmethod was added to a cache (`extensions`) before we actually tried to see if it worked. So the second time around, it was just fetched from this cache, because it had already gotten an opcode number and believed it to work.