### PR TITLE
blas: complex alpha and beta args are typed to float or double

### DIFF
--- a/extmethods/blas/templates/body_func.tpl
+++ b/extmethods/blas/templates/body_func.tpl
@@ -13,15 +13,15 @@ case @!utype!@: {
         <!--(if if_n)-->        n,             <!--(end)-->
         <!--(if if_k)-->        k,             <!--(end)-->
         @!alpha_arg!@,
-        ((@!type!@*) A_data) + A->start,
+        (@!blas_type!@*)(((@!type!@*) A_data) + A->start),
         k,
         <!--(if if_B)-->
-        ((@!type!@*) B_data) + B->start,
+        (@!blas_type!@*)(((@!type!@*) B_data) + B->start),
         n<!--(if if_C)-->,<!--(end)-->
         <!--(end)-->
         <!--(if if_C)-->
         @!beta_arg!@,
-        ((@!type!@*) C_data) + C->start,
+        (@!blas_type!@*)(((@!type!@*) C_data) + C->start),
         n
         <!--(end)-->
     );

--- a/extmethods/blas/templates/header.tpl
+++ b/extmethods/blas/templates/header.tpl
@@ -26,11 +26,11 @@ namespace {
         cblas_dgemm(layout, TransA, TransB, K, N, M, alpha, A, K, B, K, beta, C, ldc);
     }
 
-    void cblas_cgemmt(CBLAS_ORDER layout, CBLAS_TRANSPOSE TransA, CBLAS_TRANSPOSE TransB, const int M, const int N, const int K, void* alpha, const bh_complex64 *A, const int lda, const bh_complex64 *B, const int ldb, void* beta, bh_complex64 *C, const int ldc) {
+    void cblas_cgemmt(CBLAS_ORDER layout, CBLAS_TRANSPOSE TransA, CBLAS_TRANSPOSE TransB, const int M, const int N, const int K, float* alpha, const bh_complex64 *A, const int lda, const bh_complex64 *B, const int ldb, float* beta, bh_complex64 *C, const int ldc) {
         cblas_cgemm(layout, TransA, TransB, K, N, M, alpha, A, K, B, K, beta, C, ldc);
     }
 
-    void cblas_zgemmt(CBLAS_ORDER layout, CBLAS_TRANSPOSE TransA, CBLAS_TRANSPOSE TransB, const int M, const int N, const int K, void* alpha, const bh_complex128 *A, const int lda, const bh_complex128 *B, const int ldb, void* beta, bh_complex128 *C, const int ldc) {
+    void cblas_zgemmt(CBLAS_ORDER layout, CBLAS_TRANSPOSE TransA, CBLAS_TRANSPOSE TransB, const int M, const int N, const int K, double* alpha, const bh_complex128 *A, const int lda, const bh_complex128 *B, const int ldb, double* beta, bh_complex128 *C, const int ldc) {
         cblas_zgemm(layout, TransA, TransB, K, N, M, alpha, A, K, B, K, beta, C, ldc);
     }
 

--- a/extmethods/blas/templates/header.tpl
+++ b/extmethods/blas/templates/header.tpl
@@ -26,11 +26,11 @@ namespace {
         cblas_dgemm(layout, TransA, TransB, K, N, M, alpha, A, K, B, K, beta, C, ldc);
     }
 
-    void cblas_cgemmt(CBLAS_ORDER layout, CBLAS_TRANSPOSE TransA, CBLAS_TRANSPOSE TransB, const int M, const int N, const int K, float* alpha, const bh_complex64 *A, const int lda, const bh_complex64 *B, const int ldb, float* beta, bh_complex64 *C, const int ldc) {
+    void cblas_cgemmt(CBLAS_ORDER layout, CBLAS_TRANSPOSE TransA, CBLAS_TRANSPOSE TransB, const int M, const int N, const int K, float* alpha, const float *A, const int lda, const float *B, const int ldb, float* beta, float *C, const int ldc) {
         cblas_cgemm(layout, TransA, TransB, K, N, M, alpha, A, K, B, K, beta, C, ldc);
     }
 
-    void cblas_zgemmt(CBLAS_ORDER layout, CBLAS_TRANSPOSE TransA, CBLAS_TRANSPOSE TransB, const int M, const int N, const int K, double* alpha, const bh_complex128 *A, const int lda, const bh_complex128 *B, const int ldb, double* beta, bh_complex128 *C, const int ldc) {
+    void cblas_zgemmt(CBLAS_ORDER layout, CBLAS_TRANSPOSE TransA, CBLAS_TRANSPOSE TransB, const int M, const int N, const int K, double* alpha, const double *A, const int lda, const double *B, const int ldb, double* beta, double *C, const int ldc) {
         cblas_zgemm(layout, TransA, TransB, K, N, M, alpha, A, K, B, K, beta, C, ldc);
     }
 

--- a/extmethods/blas/templates/methods.json
+++ b/extmethods/blas/templates/methods.json
@@ -89,6 +89,7 @@
     "s": {
       "type":        "bh_float32",
       "scalar_type": "bh_float32",
+      "blas_type":   "bh_float32",
       "alpha":       "",
       "alpha_arg":   "1.0",
       "beta":        "",
@@ -97,6 +98,7 @@
     "d": {
       "type":        "bh_float64",
       "scalar_type": "bh_float64",
+      "blas_type":   "bh_float64",
       "alpha":       "",
       "alpha_arg":   "1.0",
       "beta":        "",
@@ -105,6 +107,7 @@
     "c": {
       "type":        "bh_complex64",
       "scalar_type": "bh_complex64",
+      "blas_type":   "bh_float32",
       "alpha":       "bh_complex64 alpha; alpha.real = 1.0; alpha.imag = 0.0;",
       "alpha_arg":   "(bh_float32*) &alpha",
       "beta":        "bh_complex64 beta; beta.real = 0.0; beta.imag = 0.0;",
@@ -113,6 +116,7 @@
     "z": {
       "type":        "bh_complex128",
       "scalar_type": "bh_complex128",
+      "blas_type":   "bh_float64",
       "alpha":       "bh_complex128 alpha; alpha.real = 1.0; alpha.imag = 0.0;",
       "alpha_arg":   "(bh_float64*) &alpha",
       "beta":        "bh_complex128 beta; beta.real = 0.0; beta.imag = 0.0;",

--- a/extmethods/blas/templates/methods.json
+++ b/extmethods/blas/templates/methods.json
@@ -106,17 +106,17 @@
       "type":        "bh_complex64",
       "scalar_type": "bh_complex64",
       "alpha":       "bh_complex64 alpha; alpha.real = 1.0; alpha.imag = 0.0;",
-      "alpha_arg":   "(void*) &alpha",
+      "alpha_arg":   "(bh_float32*) &alpha",
       "beta":        "bh_complex64 beta; beta.real = 0.0; beta.imag = 0.0;",
-      "beta_arg":    "(void*) &beta"
+      "beta_arg":    "(bh_float32*) &beta"
     },
     "z": {
       "type":        "bh_complex128",
       "scalar_type": "bh_complex128",
       "alpha":       "bh_complex128 alpha; alpha.real = 1.0; alpha.imag = 0.0;",
-      "alpha_arg":   "(void*) &alpha",
+      "alpha_arg":   "(bh_float64*) &alpha",
       "beta":        "bh_complex128 beta; beta.real = 0.0; beta.imag = 0.0;",
-      "beta_arg":    "(void*) &beta"
+      "beta_arg":    "(bh_float64*) &beta"
     }
   }
 }


### PR DESCRIPTION
In the [standard](http://www.netlib.org/blas/cblas.h), `cblas_cgemm()` and `cblas_zgemm()` takes the alpha and beta option as `float` and `double` pointers. 

In [OpenBLAS](https://github.com/xianyi/OpenBLAS/blob/develop/cblas.h), they use `float` and `double` as data pointers.

`/usr/include/cblas.h` in Ubuntu take void pointers, which makes them accept any pointer type.
