### PR TITLE
Fix CG solver

### DIFF
--- a/bridge/npbackend/cg.py
+++ b/bridge/npbackend/cg.py
@@ -4,14 +4,12 @@ Conjugate Gradient (CG) solver
 """
 
 import bohrium as np
-import bohrium.blas as blas
-import bohrium.linalg as LA
 
 from sys import stderr
 from . import ufuncs
 
 # Implemented as example MATLAB code from https://en.wikipedia.org/wiki/Conjugate_gradient_method
-def cg(A, b, x=None):
+def cg(A, b, x=None, tol=1e-5):
     # If no guess is given, set an empty guess
     if x is None:
         x = np.zeros(shape=b.shape, dtype=b.dtype)
@@ -21,20 +19,20 @@ def cg(A, b, x=None):
     rsold = np.zeros(shape=(1,1), dtype=b.dtype)
     rsnew = np.zeros(shape=(1,1), dtype=b.dtype)
 
-    r = b - np.matmul(A, x)
-    p = r;
-    rsold = blas.gemmt(r, r, c=rsold)
-
-    for _ in range(b.shape[0]):
-        Ap = np.matmul(A, p)
-        alpha = rsold / blas.gemmt(p, Ap, c=alpha)
-
+    r = b - np.dot(A, x)
+    p = r.copy()
+    r_squared = r * r
+    rsold = np.sum(r_squared)
+    
+    tol_squared = tol * tol
+    while np.max(r_squared) > tol_squared:
+        Ap = np.dot(A, p)
+        alpha = rsold / np.dot(p, Ap)
+        
         x = x + alpha * p
         r = r - alpha * Ap
-        rsnew = blas.gemmt(r, r, c=rsnew)
-
-        if LA.norm(rsnew) < 1e-10:
-            return x
+        r_squared = r * r
+        rsnew = np.sum(r_squared)
 
         p = r + (rsnew / rsold) * p
         rsold = rsnew

--- a/test/python/tests/test_ext_blas.py
+++ b/test/python/tests/test_ext_blas.py
@@ -157,9 +157,9 @@ class test_ext_cg:
             yield t
 
     def test_cg(self, t):
-        cmd_np = "res = np.array([[0.09090915], [0.63636363]], dtype=%s)" % t
+        cmd_np = "res = np.array([0.09090909, 0.63636364], dtype=%s)" % t
         cmd_bh  = "a = bh.array([[4, 1], [1, 3]], dtype=%s);" % t
-        cmd_bh += "b = bh.array([[1], [2]], dtype=%s);" % t
-        cmd_bh += "x = bh.array([[2], [1]], dtype=%s);" % t
+        cmd_bh += "b = bh.array([1, 2], dtype=%s);" % t
+        cmd_bh += "x = bh.array([2, 1], dtype=%s);" % t
         cmd_bh += "res = bh.cg.cg(a, b, x);"
         return cmd_np, cmd_bh


### PR DESCRIPTION
To fix #310, I made some changes to the CG solver:

* Instead of looping over the first axis of the RHS vector, we check for convergence in every time step (due to roundoff errors, convergence is not guaranteed after one full loop).
* I didn't understand how BLAS's ``gemmt`` was used here - as far as I get it, ``gemmt`` is used for matrix-matrix multiplications, and it only updates a triangular part of the resulting matrix. Since we are doing matrix-vector and vector-vector products here, I have replaced it with ``np.dot`` (which also seems to be faster in my crude benchmarks). I don't mean to step on anyone's toes here, though - it might very well be that using ``gemmt`` makes perfect sense and I just didn't see the deeper reason behind it. In that case, we should switch it back.
* I have added the desired solver tolerance as a keyword argument, and set it to the same value as the ``scipy.sparse.cg`` solver.

With this implementation, I achieve the same precision as the SciPy solver, but it is considerably slower than the SciPy (Fortran) version.