### PR TITLE
Fix FindCBLAS.cmake

### DIFF
--- a/cmake/Modules/FindCBLAS.cmake
+++ b/cmake/Modules/FindCBLAS.cmake
@@ -42,7 +42,7 @@ endfunction(FIND_AND_CHECK_CBLAS)
 # check Apple CBLAS
 if(APPLE)
   if(NOT CBLAS_LIBRARIES)
-    FIND_AND_CHECK_CBLAS("openblas" "cblas.h")
+    FIND_AND_CHECK_CBLAS("Accelerate" "accelerate.h")
   endif(NOT CBLAS_LIBRARIES)
 endif(APPLE)
 

--- a/cmake/Modules/FindCBLAS.cmake
+++ b/cmake/Modules/FindCBLAS.cmake
@@ -8,14 +8,24 @@
 include(FindPackageHandleStandardArgs)
 include(CheckLibraryExists)
 
-function(FIND_AND_CHECK_CBLAS _libname _includename _symbol)
+function(FIND_AND_CHECK_CBLAS _libname _includename)
   find_path(_CBLAS_INCLUDES ${_includename})
   find_library(_CBLAS_LIBRARIES NAMES ${_libname})
 
-  # check if cblas symbol is present
+  if(ARGV2) # check for optional argument
+    set(_symbol ${ARGV2})
+  endif(ARGV2)
+
   if(_CBLAS_LIBRARIES AND _CBLAS_INCLUDES)
-    get_filename_component(_LIB_PATH ${_CBLAS_LIBRARIES} DIRECTORY)
-    check_library_exists(${_libname} ${_symbol} ${_LIB_PATH} _HAVE_CBLAS_SYMBOL)
+    if(_symbol)
+      # check if given symbol is present
+      get_filename_component(_LIB_PATH ${_CBLAS_LIBRARIES} DIRECTORY)
+      check_library_exists(${_libname} ${_symbol} ${_LIB_PATH} _HAVE_CBLAS_SYMBOL)
+      unset(_LIB_PATH CACHE)
+    else()
+      set(_HAVE_CBLAS_SYMBOL True)
+    endif()
+
     if(_HAVE_CBLAS_SYMBOL)
       set(CBLAS_LIBRARIES ${_CBLAS_LIBRARIES} CACHE FILEPATH "Path to CBLAS library")
       set(CBLAS_INCLUDES ${_CBLAS_INCLUDES} CACHE PATH "Path to CBLAS include directory")
@@ -23,29 +33,32 @@ function(FIND_AND_CHECK_CBLAS _libname _includename _symbol)
   endif(_CBLAS_LIBRARIES AND _CBLAS_INCLUDES)
 
   # reset variables
+  unset(_HAVE_CBLAS_SYMBOL CACHE)
   unset(_CBLAS_INCLUDES CACHE)
   unset(_CBLAS_LIBRARIES CACHE)
 endfunction(FIND_AND_CHECK_CBLAS)
 
 
 # check Apple CBLAS
-if(NOT CBLAS_LIBRARIES)
-  FIND_AND_CHECK_CBLAS("Accelerate" "Accelerate.h" cblas_sgemm)
-endif(NOT CBLAS_LIBRARIES)
+if(APPLE)
+  if(NOT CBLAS_LIBRARIES)
+    FIND_AND_CHECK_CBLAS("openblas" "cblas.h")
+  endif(NOT CBLAS_LIBRARIES)
+endif(APPLE)
 
 # OpenBLAS
 if(NOT CBLAS_LIBRARIES)
-  FIND_AND_CHECK_CBLAS("openblas" "cblas.h" cblas_sgemm)
+  FIND_AND_CHECK_CBLAS("openblas" "cblas.h" "cblas_sgemm")
 endif(NOT CBLAS_LIBRARIES)
 
 # generic cblas / ATLAS
 if(NOT CBLAS_LIBRARIES)
-  FIND_AND_CHECK_CBLAS("cblas" "cblas.h" cblas_sgemm)
+  FIND_AND_CHECK_CBLAS("cblas" "cblas.h" "cblas_sgemm")
 endif(NOT CBLAS_LIBRARIES)
 
 # generic blas
 if(NOT CBLAS_LIBRARIES)
-  FIND_AND_CHECK_CBLAS("blas" "cblas.h" cblas_sgemm)
+  FIND_AND_CHECK_CBLAS("blas" "cblas.h" "cblas_sgemm")
 endif(NOT CBLAS_LIBRARIES)
 
 

--- a/cmake/Modules/FindCBLAS.cmake
+++ b/cmake/Modules/FindCBLAS.cmake
@@ -13,7 +13,7 @@ function(FIND_AND_CHECK_CBLAS _libname _includename _symbol)
   find_path(_CBLAS_INCLUDES ${_includename})
   find_library(_CBLAS_LIBRARIES NAMES ${_libname})
 
-  # check for if cblas symbol is present
+  # check if cblas symbol is present
   if(_CBLAS_LIBRARIES AND _CBLAS_INCLUDES) 
     set(CMAKE_REQUIRED_INCLUDES ${_CBLAS_INCLUDES})
     set(CMAKE_REQUIRED_LIBRARIES ${_CBLAS_LIBRARIES})

--- a/cmake/Modules/FindCBLAS.cmake
+++ b/cmake/Modules/FindCBLAS.cmake
@@ -6,18 +6,16 @@
 #  CBLAS_FOUND       - True if CBLAS found.
 
 include(FindPackageHandleStandardArgs)
-include(CheckSymbolExists) 
-
+include(CheckLibraryExists)
 
 function(FIND_AND_CHECK_CBLAS _libname _includename _symbol)
   find_path(_CBLAS_INCLUDES ${_includename})
   find_library(_CBLAS_LIBRARIES NAMES ${_libname})
 
   # check if cblas symbol is present
-  if(_CBLAS_LIBRARIES AND _CBLAS_INCLUDES) 
-    set(CMAKE_REQUIRED_INCLUDES ${_CBLAS_INCLUDES})
-    set(CMAKE_REQUIRED_LIBRARIES ${_CBLAS_LIBRARIES})
-    check_symbol_exists(${_symbol} ${_includename} _HAVE_CBLAS_SYMBOL)
+  if(_CBLAS_LIBRARIES AND _CBLAS_INCLUDES)
+    get_filename_component(_LIB_PATH ${_CBLAS_LIBRARIES} DIRECTORY)
+    check_library_exists(${_libname} ${_symbol} ${_LIB_PATH} _HAVE_CBLAS_SYMBOL)
     if(_HAVE_CBLAS_SYMBOL)
       set(CBLAS_LIBRARIES ${_CBLAS_LIBRARIES} CACHE FILEPATH "Path to CBLAS library")
       set(CBLAS_INCLUDES ${_CBLAS_INCLUDES} CACHE PATH "Path to CBLAS include directory")
@@ -27,7 +25,7 @@ function(FIND_AND_CHECK_CBLAS _libname _includename _symbol)
   # reset variables
   unset(_CBLAS_INCLUDES CACHE)
   unset(_CBLAS_LIBRARIES CACHE)
-endfunction(FIND_AND_CHECK_CBLAS) 
+endfunction(FIND_AND_CHECK_CBLAS)
 
 
 # check Apple CBLAS

--- a/cmake/Modules/FindCBLAS.cmake
+++ b/cmake/Modules/FindCBLAS.cmake
@@ -30,7 +30,7 @@ endfunction(FIND_AND_CHECK_CBLAS)
 
 # check Apple CBLAS
 if(NOT CBLAS_LIBRARIES)
-  FIND_AND_CHECK_CBLAS("Accelerate" "Accelerate/Accelerate.h" cblas_sgemm)
+  FIND_AND_CHECK_CBLAS("Accelerate" "Accelerate.h" cblas_sgemm)
 endif(NOT CBLAS_LIBRARIES)
 
 # OpenBLAS

--- a/cmake/Modules/FindCBLAS.cmake
+++ b/cmake/Modules/FindCBLAS.cmake
@@ -1,31 +1,210 @@
-# - Find cBLAS
-# Find the cBLAS includes and library
+# - Find CBLAS library
 #
-#  CBLAS_INCLUDES    - where to find cblas.h/Accelerate.h
-#  CBLAS_LIBRARIES   - List of libraries when using CBLAS.
-#  CBLAS_FOUND       - True if CBLAS found.
+# This module finds an installed fortran library that implements the CBLAS 
+# linear-algebra interface (see http://www.netlib.org/blas/), with CBLAS
+# interface.
+#
+# This module sets the following variables:
+#  CBLAS_FOUND - set to true if a library implementing the CBLAS interface
+#    is found
+#  CBLAS_LINKER_FLAGS - uncached list of required linker flags (excluding -l
+#    and -L).
+#  CBLAS_LIBRARIES - uncached list of libraries (using full path name) to 
+#    link against to use CBLAS
+#  CBLAS_INCLUDE_DIR - path to includes
+#  CBLAS_INCLUDE_FILE - the file to be included to use CBLAS
+#
 
-include (FindPackageHandleStandardArgs)
+include(CheckFunctionExists)
+include(CheckIncludeFile)
+include(FindPackageHandleStandardArgs)
 
-if (APPLE)
-  find_path (CBLAS_INCLUDES_PRE Accelerate.h)
-  find_library (CBLAS_LIBRARIES_PRE NAMES Accelerate)
-else ()
-  find_path (CBLAS_INCLUDES_PRE cblas.h)
-  find_library (CBLAS_LIBRARIES_PRE NAMES blas)
-endif ()
+macro(CHECK_ALL_LIBRARIES LIBRARIES _prefix _name _flags _list _include _search_include)
+  # This macro checks for the existence of the combination of fortran libraries
+  # given by _list.  If the combination is found, this macro checks (using the 
+  # Check_Fortran_Function_Exists macro) whether can link against that library
+  # combination using the name of a routine given by _name using the linker
+  # flags given by _flags.  If the combination of libraries is found and passes
+  # the link test, LIBRARIES is set to the list of complete library paths that
+  # have been found.  Otherwise, LIBRARIES is set to FALSE.
+  
+  # N.B. _prefix is the prefix applied to the names of all cached variables that
+  # are generated internally and marked advanced by this macro.
 
-# handle the QUIETLY and REQUIRED arguments and set CBLAS_FOUND to TRUE if
-# all listed variables are TRUE
+  set(__list)
+  foreach(_elem ${_list})
+    if(__list)
+      set(__list "${__list} - ${_elem}")
+    else(__list)
+      set(__list "${_elem}")
+    endif(__list)
+  endforeach(_elem)
+  message(STATUS "Checking for [${__list}]")
+  set(_libraries_work TRUE)
+  set(${LIBRARIES})
+  set(_combined_name)
+  set(_paths)
+  foreach(_library ${_list})
+    set(_combined_name ${_combined_name}_${_library})
 
-if (CBLAS_LIBRARIES_PRE)
-  set (CBLAS_LIBRARIES ${CBLAS_LIBRARIES_PRE})
-endif ()
-if (CBLAS_INCLUDES_PRE)
-  set (CBLAS_INCLUDES ${CBLAS_INCLUDES_PRE})
-  set (CBLAS_FOUND TRUE CACHE INTERNAL "")
-endif ()
+    # did we find all the libraries in the _list until now?
+    # (we stop at the first unfound one)
+    if(_libraries_work)      
+      if(APPLE) 
+        find_library(${_prefix}_${_library}_LIBRARY
+          NAMES ${_library}
+          PATHS /usr/local/lib /usr/lib /usr/local/lib64 /usr/lib64 ENV 
+          DYLD_LIBRARY_PATH 
+          )
+      else(APPLE)
+        find_library(${_prefix}_${_library}_LIBRARY
+          NAMES ${_library}
+          PATHS /usr/local/lib /usr/lib /usr/local/lib64 /usr/lib64 ENV 
+          LD_LIBRARY_PATH 
+          )
+      endif(APPLE)
+      mark_as_advanced(${_prefix}_${_library}_LIBRARY)
+      if(${_prefix}_${_library}_LIBRARY)
+        get_filename_component(_path ${${_prefix}_${_library}_LIBRARY} PATH)
+        list(APPEND _paths ${_path}/../include ${_path}/../../include)
+      endif(${_prefix}_${_library}_LIBRARY)
+      set(${LIBRARIES} ${${LIBRARIES}} ${${_prefix}_${_library}_LIBRARY})
+      set(_libraries_work ${${_prefix}_${_library}_LIBRARY})
+    endif(_libraries_work)
+  endforeach(_library ${_list})
 
-find_package_handle_standard_args (CBLAS DEFAULT_MSG CBLAS_LIBRARIES CBLAS_INCLUDES)
+  # Test include
+  set(_bug_search_include ${_search_include}) #CMAKE BUG!!! SHOULD NOT BE THAT
+  if(_bug_search_include)
+    find_path(${_prefix}${_combined_name}_INCLUDE ${_include} ${_paths})
+    mark_as_advanced(${_prefix}${_combined_name}_INCLUDE)
+    if(${_prefix}${_combined_name}_INCLUDE)
+      message(STATUS "Checking for [${__list}] -- includes found")
+      set(${_prefix}_INCLUDE_DIR ${${_prefix}${_combined_name}_INCLUDE})
+      set(${_prefix}_INCLUDE_FILE ${_include})
+    else(${_prefix}${_combined_name}_INCLUDE)
+      message(STATUS "Checking for [${__list}] -- includes not found")
+      set(_libraries_work FALSE)
+    endif(${_prefix}${_combined_name}_INCLUDE)
+  else(_bug_search_include)
+    set(${_prefix}_INCLUDE_DIR)
+    set(${_prefix}_INCLUDE_FILE ${_include})
+  endif(_bug_search_include)
 
-mark_as_advanced (CBLAS_LIBRARIES CBLAS_INCLUDES)
+  if(_libraries_work)
+    # Test this combination of libraries.
+    set(CMAKE_REQUIRED_LIBRARIES ${_flags} ${${LIBRARIES}})
+    CHECK_FUNCTION_EXISTS(${_name} ${_prefix}${_combined_name}_WORKS)
+    set(CMAKE_REQUIRED_LIBRARIES)
+    mark_as_advanced(${_prefix}${_combined_name}_WORKS)
+    set(_libraries_work ${${_prefix}${_combined_name}_WORKS})
+
+    if(_libraries_work)
+      message(STATUS "Checking for [${__list}] -- libraries found")
+    endif(_libraries_work)
+
+  endif(_libraries_work)
+  
+
+  if(NOT _libraries_work)
+    set(${LIBRARIES} FALSE)
+  endif(NOT _libraries_work)
+
+ENDMACRO(CHECK_ALL_LIBRARIES)
+
+set(CBLAS_LINKER_FLAGS)
+set(CBLAS_LIBRARIES)
+
+# CBLAS in intel mkl library? (shared)
+if(NOT CBLAS_LIBRARIES)
+  CHECK_ALL_LIBRARIES(
+    CBLAS_LIBRARIES
+    CBLAS
+    cblas_sgemm
+    ""
+    "mkl;guide;pthread"
+    "mkl_cblas.h"
+    TRUE
+    )
+endif(NOT CBLAS_LIBRARIES)
+
+#CBLAS in intel mkl library? (static, 32bit)
+if(NOT CBLAS_LIBRARIES)
+  CHECK_ALL_LIBRARIES(
+    CBLAS_LIBRARIES
+    CBLAS
+    cblas_sgemm
+    ""
+    "mkl_ia32;guide;pthread"
+    "mkl_cblas.h"
+    TRUE
+    )
+endif(NOT CBLAS_LIBRARIES)
+
+#CBLAS in intel mkl library? (static, em64t 64bit)
+if(NOT CBLAS_LIBRARIES)
+  CHECK_ALL_LIBRARIES(
+    CBLAS_LIBRARIES
+    CBLAS
+    cblas_sgemm
+    ""
+    "mkl_em64t;guide;pthread"
+    "mkl_cblas.h"
+    ON
+    )
+endif(NOT CBLAS_LIBRARIES)
+
+if(NOT CBLAS_LIBRARIES)
+  # CBLAS in ATLAS library? (http://math-atlas.sourceforge.net/)
+  CHECK_ALL_LIBRARIES(
+    CBLAS_LIBRARIES
+    CBLAS
+    cblas_dgemm
+    ""
+    "cblas;f77blas;atlas"
+    "cblas.h"
+    TRUE
+    )
+endif(NOT CBLAS_LIBRARIES)
+
+if(NOT CBLAS_LIBRARIES)
+  # CBLAS in OpenBLAS library?
+  CHECK_ALL_LIBRARIES(
+    CBLAS_LIBRARIES
+    CBLAS
+    cblas_dgemm
+    ""
+    "openblas"
+    "cblas.h"
+    TRUE
+    )
+endif(NOT CBLAS_LIBRARIES)
+
+# Apple CBLAS library?
+if(NOT CBLAS_LIBRARIES)
+  CHECK_ALL_LIBRARIES(
+    CBLAS_LIBRARIES
+    CBLAS
+    cblas_dgemm
+    ""
+    "Accelerate"
+    "Accelerate/Accelerate.h"
+    FALSE
+    )
+endif(NOT CBLAS_LIBRARIES)
+
+if(NOT CBLAS_LIBRARIES)
+  CHECK_ALL_LIBRARIES(
+    CBLAS_LIBRARIES
+    CBLAS
+    cblas_dgemm
+    ""
+    "vecLib"
+    "vecLib/vecLib.h"
+    FALSE
+    )
+endif(NOT CBLAS_LIBRARIES)
+
+find_package_handle_standard_args(CBLAS DEFAULT_MSG CBLAS_LIBRARIES CBLAS_INCLUDES)
+
+mark_as_advanced(CBLAS_LIBRARIES CBLAS_INCLUDES)

--- a/extmethods/blas/CMakeLists.txt
+++ b/extmethods/blas/CMakeLists.txt
@@ -38,8 +38,4 @@ if(CBLAS_FOUND)
     install(TARGETS bh_blas DESTINATION ${LIBDIR} COMPONENT bohrium)
 
     set(OPENMP_LIBS ${OPENMP_LIBS} "${CMAKE_INSTALL_PREFIX}/lib/libbh_blas${CMAKE_SHARED_LIBRARY_SUFFIX}" PARENT_SCOPE)
-else()
-    if (CBLAS_INCLUDES_PRE)
-        set_package_properties(BLAS PROPERTIES TYPE RECOMMENDED PURPOSE "CBLAS was found, but not enabled. \n   Manually enable BLAS with CBLAS_INCLUDES and CBLAS_LIBRARIES.")
-    endif()
 endif()

--- a/package/conda/bohrium/build.sh
+++ b/package/conda/bohrium/build.sh
@@ -28,7 +28,6 @@ cmake .. -DCMAKE_BUILD_TYPE=Release \
          -DBoost_NO_SYSTEM_PATHS=ON \
 	 -DBOOST_ROOT=$PWD/boost \
 	 -DBoost_USE_STATIC_LIBS=ON \
-	 -DCBLAS_LIBRARIES=$CONDA_PREFIX/lib/libopenblas.so \
 	 -DLAPACKE_LIBRARIES=$CONDA_PREFIX/lib/libopenblas.so \
 	 -DCORE_LINK_FLAGS="-static-libgcc -static-libstdc++" \
 	 -DFORCE_CONFIG_PATH=$PREFIX/etc/bohrium \

--- a/package/debian/build-package.py
+++ b/package/debian/build-package.py
@@ -16,13 +16,13 @@ Source: bohrium
 Section: devel
 Priority: optional
 Maintainer: Bohrium Builder <builder@bh107.org>
-Build-Depends: python-dev, python-numpy, cython, python3-dev, python3-numpy, python3-dev, cython3, debhelper, cmake, swig, fftw3-dev, ocl-icd-opencl-dev, libgl-dev, libboost-serialization-dev, libboost-filesystem-dev, libboost-system-dev, libboost-regex-dev, mono-devel, libhwloc-dev, freeglut3-dev, libxmu-dev, libxi-dev, zlib1g-dev, libblas-dev, liblapack-dev, liblapacke-dev
+Build-Depends: python-dev, python-numpy, cython, python3-dev, python3-numpy, python3-dev, cython3, debhelper, cmake, swig, fftw3-dev, ocl-icd-opencl-dev, libgl-dev, libboost-serialization-dev, libboost-filesystem-dev, libboost-system-dev, libboost-regex-dev, mono-devel, libhwloc-dev, freeglut3-dev, libxmu-dev, libxi-dev, zlib1g-dev, libopenblas-dev, liblapack-dev, liblapacke-dev
 Standards-Version: 3.9.5
 Homepage: http://www.bh107.org
 
 Package: bohrium
 Architecture: amd64
-Depends: build-essential, libboost-dev, python (>= 2.7), python-numpy (>= 1.8), fftw3, libboost-serialization-dev, libboost-filesystem-dev, libboost-system-dev, libboost-regex-dev, libhwloc-dev, libblas-dev, liblapack-dev
+Depends: build-essential, libboost-dev, python (>= 2.7), python-numpy (>= 1.8), fftw3, libboost-serialization-dev, libboost-filesystem-dev, libboost-system-dev, libboost-regex-dev, libhwloc-dev, libopenblas-dev, liblapack-dev
 Recommends:
 Suggests: bohrium-numcil, bohrium-opencl, bohrium-visualizer, ipython,
 Description:  Bohrium Runtime System: Automatic Vector Parallelization in C, C++, CIL, and Python

--- a/package/docker/base.dockerfile
+++ b/package/docker/base.dockerfile
@@ -15,7 +15,7 @@ RUN apt-get -qq install wget unzip build-essential > /dev/null
 RUN apt-get -qq install cmake swig python python-numpy python-dev cython > /dev/null
 RUN apt-get -qq install libboost-serialization-dev libboost-system-dev libboost-filesystem-dev libboost-thread-dev libboost-regex-dev > /dev/null
 RUN apt-get -qq install mono-mcs mono-xbuild libmono-system-numerics4.0-cil libmono-microsoft-build-tasks-v4.0-4.0-cil > /dev/null
-RUN apt-get -qq install libblas-dev libclblas-dev liblapacke-dev > /dev/null
+RUN apt-get -qq install libopenblas-dev libclblas-dev liblapacke-dev > /dev/null
 RUN apt-get -qq install fftw3-dev libgl1-mesa-dev > /dev/null
 RUN apt-get -qq install python3 python3-numpy python3-dev cython3 > /dev/null
 RUN apt-get -qq install python2.7-scipy python3-scipy > /dev/null

--- a/package/docker/base.dockerfile
+++ b/package/docker/base.dockerfile
@@ -3,7 +3,10 @@ MAINTAINER Mads R. B. Kristensen <madsbk@gmail.com>
 RUN mkdir -p /bohrium/build
 WORKDIR /bohrium/build
 
+RUN apt-get -qq update > /dev/null
+
 # Set the locale
+RUN apt-get -qq install locales > /dev/null
 RUN locale-gen en_US.UTF-8
 ENV LANG en_US.UTF-8
 ENV LANGUAGE en_US:en


### PR DESCRIPTION
Depending on the setup, the CBLAS symbols may or may not be present in a given BLAS library. This has been leading to "undefined symbol" errors during runtime in certain situations. I re-wrote the CMake module to check if the CBLAS symbols are actually present in the found library. It also checks several common BLAS library names (`Accelerate`, `libopenblas`, `libcblas`, `libblas`).

This fixes #320 and some issues I had with the conda package (since the conda libraries now correctly link against `libopenblas.so` provided by Anaconda).