### PR TITLE
NaN-frienly version of where

### DIFF
--- a/test/python/tests/test_mask.py
+++ b/test/python/tests/test_mask.py
@@ -75,3 +75,11 @@ class test_where:
         cmd += "res = M.where(m, a, b)"
         return cmd
 
+    def test_nanarray(self, arg):
+        (cmd, dtype) = arg
+        if dtype in util.TYPES.FLOAT:
+            cmd += "a[0] = M.nan;"
+            cmd += "res = M.where(M.isnan(a), M.ones_like(a), a)"
+            return cmd
+        else:
+            return "res = 0"


### PR DESCRIPTION
Fixes #258 and #260. Also does somewhat more robust type-checking in order to match the NumPy casting rules. I hope this version isn't too bad performance-wise, since it makes use of the new Bohrium fancy indexing.