### PR TITLE
Fix bh.where again

### DIFF
--- a/bridge/npbackend/masking.py
+++ b/bridge/npbackend/masking.py
@@ -7,6 +7,8 @@ import warnings
 from . import array_create
 from . import bhary
 from . import reorganization
+from . import array_manipulation
+from . import ufuncs
 import numpy_force as numpy
 from .bhary import fix_biclass_wrapper
 
@@ -91,7 +93,7 @@ def where(condition, x=None, y=None):
     # Let's find a non-scalar and make sure that non-scalars are Bohrium arrays
     t = None
     if not numpy.isscalar(condition):
-        condition = array_create.array(condition)
+        condition = array_create.array(condition).astype("bool")
         t = condition
 
     if not numpy.isscalar(x):
@@ -109,6 +111,14 @@ def where(condition, x=None, y=None):
         else:
             return y
 
+    # Shortcut if input arrays are finite
+    try:
+        if ufuncs.isfinite(x).all() and ufuncs.isfinite(y).all():
+            return condition * x + ~condition * y
+    except TypeError: # ufuncs.isfinite does not support all dtypes
+        if numpy.isfinite(x).all() and numpy.isfinite(y).all():
+            return condition * x + ~condition * y
+
     # Find appropriate output type
     array_types = []
     scalar_types = []
@@ -119,15 +129,11 @@ def where(condition, x=None, y=None):
             array_types.append(v.dtype)
     out_type = numpy.find_common_type(array_types, scalar_types)
 
-    ret = array_create.zeros(t.shape, dtype=out_type)
-    if numpy.isscalar(x):
-        ret[condition] = x
-    else:
-        ret[condition] = x[condition]
-    if numpy.isscalar(y):
-        ret[~condition] = y
-    else:
-        ret[~condition] = y[~condition]
+    condition, x, y = array_manipulation.broadcast_arrays(condition, x, y)
+
+    ret = array_create.zeros(condition.shape, dtype=out_type)
+    ret[condition] = x[condition]
+    ret[~condition] = y[~condition]
     return ret
 
 

--- a/bridge/npbackend/masking.py
+++ b/bridge/npbackend/masking.py
@@ -116,7 +116,9 @@ def where(condition, x=None, y=None):
         if ufuncs.isfinite(x).all() and ufuncs.isfinite(y).all():
             return condition * x + ~condition * y
     except TypeError: # ufuncs.isfinite does not support all dtypes
-        if numpy.isfinite(x).all() and numpy.isfinite(y).all():
+        xn = x if numpy.isscalar(x) else x.copy2numpy()
+        yn = y if numpy.isscalar(y) else y.copy2numpy()
+        if numpy.isfinite(xn).all() and numpy.isfinite(yn).all():
             return condition * x + ~condition * y
 
     # Find appropriate output type


### PR DESCRIPTION
Sorry guys, I messed up. My previous change to ``bh.where`` was flawed in that it

1. did not cast the condition to `bool` (so calling with e.g. an integer array would give unexpected results)
2. did not do correct array broadcasting
3. had horrible overall performance

I have added a shortcut for arrays that do not contain any `nan` or `inf` values, so performance for those arrays is back to normal. However, if any of the arrays contains non-finite values, this will be *slow* (but at least it works properly). I am wondering whether a performance warning should be issued in that case, to make this behavior a bit less surprising.