### PR TITLE
Use uint32 for graphic id

### DIFF
--- a/ve/opencl/main.cpp
+++ b/ve/opencl/main.cpp
@@ -173,7 +173,7 @@ void Impl::write_kernel(const Kernel &kernel, const SymbolTable &symbols, const 
         for (unsigned int i=0; i < threaded_blocks.size(); ++i) {
             const LoopB *b = threaded_blocks[i];
             spaces(ss, 4);
-            ss << "const " << write_opencl_type(BH_UINT64) << " i" << b->rank << " = get_global_id(" << i << "); " \
+            ss << "const " << write_opencl_type(BH_UINT32) << " i" << b->rank << " = get_global_id(" << i << "); " \
                << "if (i" << b->rank << " >= " << b->size << ") {return;} // Prevent overflow\n";
         }
         ss << "\n";


### PR DESCRIPTION
This should solve #327 and the problem stated in http://stackoverflow.com/questions/43887942/opencl-1-2-gives-9999-error-with-valid-kernel