### PR TITLE
Put stats in YML-file if supplied

### DIFF
--- a/config.ini.in
+++ b/config.ini.in
@@ -66,6 +66,7 @@ impl = ${CMAKE_INSTALL_PREFIX}/${LIBDIR}/libbh_ve_openmp${CMAKE_SHARED_LIBRARY_S
 verbose = false
 # Profiling statistics
 prof = false
+prof_filename =
 # Write a Graphviz graph for each kernel
 graph = false
 compiler_cmd = "${VE_OPENMP_COMPILER_CMD}"
@@ -90,6 +91,7 @@ impl = ${CMAKE_INSTALL_PREFIX}/${LIBDIR}/libbh_ve_opencl${CMAKE_SHARED_LIBRARY_S
 verbose = false
 # Profiling statistics
 prof = false
+prof_filename =
 # Write a Graphviz graph for each kernel
 graph = false
 # Device type can be one of 'auto', 'gpu', 'cpu', 'accelerator', or 'default'
@@ -121,6 +123,7 @@ impl = ${CMAKE_INSTALL_PREFIX}/${LIBDIR}/libbh_ve_cuda${CMAKE_SHARED_LIBRARY_SUF
 verbose = false
 # Profiling statistics
 prof = false
+prof_filename =
 # Write a Graphviz graph for each kernel
 graph = false
 # Device type can be one of 'auto', 'gpu', 'cpu', 'accelerator', or 'default'

--- a/include/jitk/statistics.hpp
+++ b/include/jitk/statistics.hpp
@@ -25,6 +25,7 @@ If not, see <http://www.gnu.org/licenses/>.
 #include <string>
 #include <ostream>
 #include <sstream>
+#include <fstream>
 #include <vector>
 
 #include <bh_instruction.hpp>
@@ -65,43 +66,90 @@ class Statistics {
     std::chrono::duration<double> time_offload{0};
     std::chrono::duration<double> time_copy2dev{0};
     std::chrono::duration<double> time_copy2host{0};
+
+    std::chrono::duration<double> wallclock{0};
     std::chrono::time_point<std::chrono::steady_clock> time_started{std::chrono::steady_clock::now()};
 
     Statistics(bool enabled) : enabled(enabled) {}
 
+    void write(std::string backend_name, std::string filename, std::ostream &out) {
+        if (filename == "") {
+            pprint(backend_name, out);
+        } else {
+            export_json(backend_name, filename);
+        }
+    }
+
     // Pretty print the recorded statistics into 'out' where 'backend_name' is the name of the caller
     void pprint(std::string backend_name, std::ostream &out) {
         using namespace std;
-        const chrono::duration<double> wallclock{chrono::steady_clock::now() - time_started};
 
-        chrono::duration<double> time_other{0};
-        time_other = time_total_execution - time_pre_fusion - time_fusion - time_compile - time_exec  - time_copy2dev - time_copy2host - time_offload;
+        if (enabled) {
+            wallclock = chrono::steady_clock::now() - time_started;
 
-        out << BLU << "[" << backend_name << "] Profiling: \n" << RST;
-        out << "Fuse cache hits:                 " << GRN << pprint_ratio(fuser_cache_lookups - fuser_cache_misses, fuser_cache_lookups) << "\n" << RST;
-        out << "Kernel cache hits                " << GRN << pprint_ratio(kernel_cache_lookups - kernel_cache_misses, kernel_cache_lookups) << "\n" << RST;
-        out << "Array contractions:              " << GRN << pprint_ratio(num_temp_arrays, num_base_arrays) << "\n" << RST;
-        out << "Outer-fusion ratio:              " << GRN << pprint_ratio(num_blocks_out_of_fuser, num_instrs_into_fuser) << "\n" << RST;
-        out << "\n";
-        out << "Max memory usage:                " << GRN << max_memory_usage / 1024 / 1024 << " MB\n" << RST;
-        out << "Syncs to NumPy:                  " << GRN << num_syncs << "\n" << RST;
-        out << "Total Work:                      " << GRN << (double) totalwork << " operations\n" << RST;
-        out << "Throughput:                      " << GRN << totalwork / (double) wallclock.count() << "ops\n" << RST;
-        out << "Work below par-threshold (1000): " << GRN << threading_below_threshold / (double) totalwork * 100 << "%\n" << RST;
-        out << "\n";
-        out << "Wall clock:                      " << BLU << wallclock.count() << "s\n" << RST;
-        out << "Total Execution:                 " << BLU << time_total_execution.count() << "s\n" << RST;
-        out << "  Pre-fusion:                    " << YEL << time_pre_fusion.count() << "s\n" << RST;
-        out << "  Fusion:                        " << YEL << time_fusion.count() << "s\n" << RST;
-        out << "  Compile:                       " << YEL << time_compile.count() << "s\n" << RST;
-        out << "  Exec:                          " << YEL << time_exec.count() << "s\n" << RST;
-        out << "  Copy2dev:                      " << YEL << time_copy2dev.count() << "s\n" << RST;
-        out << "  Copy2host:                     " << YEL << time_copy2host.count() << "s\n" << RST;
-        out << "  Offload:                       " << YEL << time_offload.count() << "s\n" << RST;
-        out << "  Other:                         " << YEL << time_other.count() << "s\n" << RST;
-        out << "\n";
-        out << BOLD << RED << "Unaccounted for (wall-total):    " << (wallclock - time_total_execution).count() << "s\n" << RST;
-        out << endl;
+            out << BLU << "[" << backend_name << "] Profiling: \n" << RST;
+            out << "Fuse cache hits:                 " << GRN << fuse_cache_hits()                   << "\n" << RST;
+            out << "Kernel cache hits                " << GRN << kernel_cache_hits()                 << "\n" << RST;
+            out << "Array contractions:              " << GRN << array_contractions()                << "\n" << RST;
+            out << "Outer-fusion ratio:              " << GRN << outer_fusion_ratio()                << "\n" << RST;
+            out << "\n";
+            out << "Max memory usage:                " << GRN << memory_usage() << " MB"             << "\n" << RST;
+            out << "Syncs to NumPy:                  " << GRN << num_syncs                           << "\n" << RST;
+            out << "Total Work:                      " << GRN << totalwork << " operations"          << "\n" << RST;
+            out << "Throughput:                      " << GRN << throughput() << "ops"               << "\n" << RST;
+            out << "Work below par-threshold (1000): " << GRN << work_below_thredshold() << "%"      << "\n" << RST;
+            out << "\n";
+            out << "Wall clock:                      " << BLU << wallclock.count() << "s"            << "\n" << RST;
+            out << "Total Execution:                 " << BLU << time_total_execution.count() << "s" << "\n" << RST;
+            out << "  Pre-fusion:                    " << YEL << time_pre_fusion.count() << "s"      << "\n" << RST;
+            out << "  Fusion:                        " << YEL << time_fusion.count() << "s"          << "\n" << RST;
+            out << "  Compile:                       " << YEL << time_compile.count() << "s"         << "\n" << RST;
+            out << "  Exec:                          " << YEL << time_exec.count() << "s"            << "\n" << RST;
+            out << "  Copy2dev:                      " << YEL << time_copy2dev.count() << "s"        << "\n" << RST;
+            out << "  Copy2host:                     " << YEL << time_copy2host.count() << "s"       << "\n" << RST;
+            out << "  Offload:                       " << YEL << time_offload.count() << "s"         << "\n" << RST;
+            out << "  Other:                         " << YEL << time_other() << "s"                 << "\n" << RST;
+            out << "\n";
+            out << BOLD << RED << "Unaccounted for (wall - total):  " << unaccounted() << "s\n" << RST;
+            out << endl;
+        }
+    }
+
+    void export_json(std::string backend_name, std::string filename) {
+        using namespace std;
+
+        if (enabled) {
+            wallclock = chrono::steady_clock::now() - time_started;
+
+            ofstream file;
+            file.open(filename);
+
+            file << "----"                                                      << "\n";
+            file << backend_name << ":"                                         << "\n";
+            file << "  fuse_cache_hits: "       << fuse_cache_hits()            << "\n";
+            file << "  kernel_cache_hits: "     << kernel_cache_hits()          << "\n";
+            file << "  array_contractions: "    << array_contractions()         << "\n";
+            file << "  outer_fusion_ratio: "    << outer_fusion_ratio()         << "\n";
+            file << "  memory_usage: "          << memory_usage()               << "\n"; // mb
+            file << "  syncs: "                 << num_syncs                    << "\n";
+            file << "  total_work: "            << totalwork                    << "\n"; // ops
+            file << "  throughput: "            << throughput()                 << "\n"; // ops
+            file << "  work_below_thredshold: " << work_below_thredshold()      << "\n"; // %
+            file << "  timing:"                                                 << "\n";
+            file << "    wall_clock: "          << wallclock.count()            << "\n"; // s
+            file << "    total_execution: "     << time_total_execution.count() << "\n"; // s
+            file << "    pre_fusion: "          << time_pre_fusion.count()      << "\n"; // s
+            file << "    fusion: "              << time_fusion.count()          << "\n"; // s
+            file << "    compile: "             << time_compile.count()         << "\n"; // s
+            file << "    exec: "                << time_exec.count()            << "\n"; // s
+            file << "    copy2dev: "            << time_copy2dev.count()        << "\n"; // s
+            file << "    copy2host: "           << time_copy2host.count()       << "\n"; // s
+            file << "    offload: "             << time_offload.count()         << "\n"; // s
+            file << "    other: "               << time_other()                 << "\n"; // s
+            file << "    unaccounted: "         << unaccounted()                << "\n"; // s
+
+            file.close();
+        }
     }
 
     // Record statistics based on the 'instr_list'
@@ -112,11 +160,50 @@ class Statistics {
                     const std::vector<bh_index> shape = instr.shape();
                     totalwork += bh_nelements(shape.size(), &shape[0]);
                 }
+
                 if (instr.opcode == BH_SYNC) {
                     ++num_syncs;
                 }
             }
         }
+    }
+
+  private:
+    std::string fuse_cache_hits() {
+        return pprint_ratio(fuser_cache_lookups - fuser_cache_misses, fuser_cache_lookups);
+    }
+
+    std::string kernel_cache_hits() {
+        return pprint_ratio(kernel_cache_lookups - kernel_cache_misses, kernel_cache_lookups);
+    }
+
+    std::string array_contractions() {
+        return pprint_ratio(num_temp_arrays, num_base_arrays);
+    }
+
+    std::string outer_fusion_ratio() {
+        return pprint_ratio(num_blocks_out_of_fuser, num_instrs_into_fuser);
+    }
+
+    double memory_usage() {
+        return (double) max_memory_usage / 1024.0 / 1024.0;
+    }
+
+    double throughput() {
+        return (double) totalwork / (double) wallclock.count();
+    }
+
+    double work_below_thredshold() {
+        return (double) threading_below_threshold / (double) totalwork * 100.0;
+    }
+
+    double time_other() {
+        std::chrono::duration<double> time_other{0};
+        return (time_total_execution - time_pre_fusion - time_fusion - time_compile - time_exec  - time_copy2dev - time_copy2host - time_offload).count();
+    }
+
+    double unaccounted() {
+        return (wallclock - time_total_execution).count();
     }
 };
 

--- a/ve/cuda/main.cpp
+++ b/ve/cuda/main.cpp
@@ -111,9 +111,7 @@ extern "C" void destroy(ComponentImpl* self) {
 }
 
 Impl::~Impl() {
-    if (config.defaultGet<bool>("prof", false)) {
-        stat.pprint("CUDA", cout);
-    }
+    stat.write("CUDA", config.defaultGet<std::string>("prof_filename", ""), cout);
 }
 
 

--- a/ve/opencl/main.cpp
+++ b/ve/opencl/main.cpp
@@ -111,9 +111,7 @@ extern "C" void destroy(ComponentImpl* self) {
 }
 
 Impl::~Impl() {
-    if (config.defaultGet<bool>("prof", false)) {
-        stat.pprint("OpenCL", cout);
-    }
+    stat.write("OpenCL", config.defaultGet<std::string>("prof_filename", ""), cout);
 }
 
 

--- a/ve/openmp/main.cpp
+++ b/ve/openmp/main.cpp
@@ -100,9 +100,7 @@ extern "C" void destroy(ComponentImpl* self) {
 }
 
 Impl::~Impl() {
-    if (config.defaultGet<bool>("prof", false)) {
-        stat.pprint("OpenMP", cout);
-    }
+    stat.write("OpenMP", config.defaultGet<std::string>("prof_filename", ""), cout);
 }
 
 // Writing the OpenMP header, which include "parallel for" and "simd"


### PR DESCRIPTION
We might want to work further with this JSON-file to also have it include stuff from the various bridges, so we can profile these, as this may be where most of the "unaccounted" time is coming from.