### PR TITLE
Amendments to C++ bridge and verbose codegeneration output typo

### DIFF
--- a/bridge/cpp/bxx/bohrium.hpp
+++ b/bridge/cpp/bxx/bohrium.hpp
@@ -290,7 +290,17 @@ protected:
 private:
     void reset_meta();						// Helper, shared among constructors
 
+    template <typename S>
+    friend void swap(multi_array<S>& lhs, multi_array<S>& rhs);
 };
+
+template <typename T>
+inline void swap(multi_array<T>& lhs, multi_array<T>& rhs) {
+    using std::swap;
+    swap(lhs.temp_, rhs.temp_);
+    swap(lhs.slicing_dim_, rhs.slicing_dim_);
+    swap(lhs.meta, rhs.meta);
+}
 
 template <typename TL, typename TR>
 inline

--- a/bridge/cpp/bxx/bohrium.hpp
+++ b/bridge/cpp/bxx/bohrium.hpp
@@ -190,8 +190,8 @@ public:
     // Types:
     typedef multi_array_iter<T> iterator;
 
-    size_t len();
-    int64_t shape(int64_t dim);             // Probe for the shape of the given dimension
+    size_t len() const;
+    int64_t shape(int64_t dim) const;             // Probe for the shape of the given dimension
     unsigned long getRank() const;
 
     // Iterator

--- a/bridge/cpp/bxx/multi_array.hpp
+++ b/bridge/cpp/bxx/multi_array.hpp
@@ -203,7 +203,7 @@ unsigned long multi_array<T>::getRank() const
 
 template <typename T>
 inline
-size_t multi_array<T>::len()
+size_t multi_array<T>::len() const
 {
     size_t nelements = 1;
     for (int i = 0; i < meta.ndim; ++i) {
@@ -214,7 +214,7 @@ size_t multi_array<T>::len()
 
 template <typename T>
 inline
-int64_t multi_array<T>::shape(int64_t dim)
+int64_t multi_array<T>::shape(int64_t dim) const
 {
     if (dim>=meta.ndim) {
         throw std::runtime_error("Dude you are like totally out of bounds!\n");

--- a/include/jitk/codegen_util.hpp
+++ b/include/jitk/codegen_util.hpp
@@ -269,8 +269,10 @@ void handle_execution(SelfType &self, bh_ir *bhir, EngineType &engine, const Con
             self.write_kernel(kernel, symbols, config, threaded_blocks, offset_strides, ss);
 
             if (verbose) {
-                cout << "\n************ GPU Kernel ************\n" << ss.str()
-                     << "^^^^^^^^^^^^ Kernel End ^^^^^^^^^^^^" << endl;
+                cout << '\n'
+                     << "************ Kernel Begin ************" << '\n'
+                     << ss.str()
+                     << "^^^^^^^^^^^^  Kernel End  ^^^^^^^^^^^^" << endl;
             }
 
             // Create the constant vector


### PR DESCRIPTION
- The swap function is nice to have in downstream, since it makes it easier to manage multi_array objects without needing knowledge of the internals that much
- The ``const``s don't hurt, so they should be around.