### PR TITLE
CUDA indices are int64

### DIFF
--- a/ve/cuda/main.cpp
+++ b/ve/cuda/main.cpp
@@ -126,7 +126,7 @@ void loop_head_writer(const SymbolTable &symbols, Scope &scope, const LoopB &blo
     // Notice that we use find_if() with a lambda function since 'threaded_blocks' contains pointers not objects
     if (std::find_if(threaded_blocks.begin(), threaded_blocks.end(),
                      [&block](const LoopB* b){return *b == block;}) == threaded_blocks.end()) {
-        out << "for(" << write_cuda_type(BH_UINT64) << " " << itername;
+        out << "for(" << write_cuda_type(BH_INT64) << " " << itername;
         if (block._sweeps.size() > 0 and loop_is_peeled) // If the for-loop has been peeled, we should start at 1
             out << " = 1; ";
         else
@@ -175,7 +175,7 @@ void Impl::write_kernel(const Kernel &kernel, const SymbolTable &symbols, const 
         for (unsigned int i=0; i < threaded_blocks.size(); ++i) {
             const LoopB *b = threaded_blocks[i];
             spaces(ss, 4);
-            ss << "const int i" << b->rank << " = " << write_thread_id(i) << "; " \
+            ss << "const " << write_cuda_type(BH_INT64) << " i" << b->rank << " = " << write_thread_id(i) << "; " \
                << "if (i" << b->rank << " >= " << b->size << ") { return; } // Prevent overflow\n";
         }
         ss << "\n";


### PR DESCRIPTION
This means that we won't get the

```
warning: integer conversion resulted in a change of sign
```

warning anymore, but also, that indices can't be more than 9,223,372,036,854,775,807.