### PR TITLE
One-liner fixes in cpp bridge

### DIFF
--- a/bridge/cpp/bxx/bohrium.hpp
+++ b/bridge/cpp/bxx/bohrium.hpp
@@ -182,7 +182,7 @@ public:
     multi_array(const multi_array<OtherT> &operand);    // Copy
 
     template <typename ...Dimensions>                   // Variadic constructor
-    multi_array(Dimensions... dims);
+    explicit multi_array(Dimensions... dims);
 
     // ** Deconstructor **
     ~multi_array();

--- a/bridge/cpp/bxx/traits.hpp
+++ b/bridge/cpp/bxx/traits.hpp
@@ -33,7 +33,7 @@ namespace bxx {
 inline
 void assign_const_type(bh_constant* constant, T value) {
     //TODO: The general case should result in a meaningful compile-time error.
-    std::cout << "Unsupported type [%s, " << constant->type << "] " << &value << std::cout;
+    std::cout << "Unsupported type [%s, " << constant->type << "] " << &value << std::endl;
 }
 
     template <>


### PR DESCRIPTION
- Commit 4bd2e42 makes the variadic construct explicit such that the compiler does no longer falls back to this constructor if a type mismatch occurs when calling functions involving ``multi_array<T>`` arguments.
- Commit c6b555b corrects a typo