### PR TITLE
Reformatting and renaming in bhxx bridge

### DIFF
--- a/bridge/cxx/.clang-format
+++ b/bridge/cxx/.clang-format
@@ -1,0 +1,85 @@
+## ---------------------------------------------------------------------
+##
+## Licence header 
+##
+## ---------------------------------------------------------------------
+
+---
+Language:        Cpp
+AccessModifierOffset: -2
+AlignAfterOpenBracket: Align
+AlignConsecutiveAssignments: true
+AlignConsecutiveDeclarations: true
+AlignEscapedNewlinesLeft: true
+AlignOperands:   true
+AlignTrailingComments: true
+AllowAllParametersOfDeclarationOnNextLine: true
+AllowShortBlocksOnASingleLine: false
+AllowShortCaseLabelsOnASingleLine: false
+AllowShortFunctionsOnASingleLine: All
+AllowShortIfStatementsOnASingleLine: true
+AllowShortLoopsOnASingleLine: true
+AlwaysBreakAfterReturnType: None
+AlwaysBreakBeforeMultilineStrings: true
+AlwaysBreakTemplateDeclarations: true
+BinPackArguments: true
+BinPackParameters: true
+BraceWrapping:   
+  AfterClass:      false
+  AfterControlStatement: false
+  AfterEnum:       false
+  AfterFunction:   false
+  AfterNamespace:  false
+  AfterObjCDeclaration: false
+  AfterStruct:     false
+  AfterUnion:      false
+  BeforeCatch:     false
+  BeforeElse:      false
+  IndentBraces:    false
+BreakBeforeBinaryOperators: None
+BreakBeforeBraces: Attach
+BreakBeforeTernaryOperators: true
+BreakConstructorInitializersBeforeComma: false
+ColumnLimit:     90
+CommentPragmas:  '^ IWYU pragma:'
+ConstructorInitializerAllOnOneLineOrOnePerLine: true
+ConstructorInitializerIndentWidth: 6
+ContinuationIndentWidth: 6
+Cpp11BracedListStyle: true
+DerivePointerAlignment: false
+DisableFormat:   false
+ExperimentalAutoDetectBinPacking: false
+ForEachMacros:   [ foreach, Q_FOREACH, BOOST_FOREACH ]
+IndentCaseLabels: true
+IndentWidth:     4
+IndentWrappedFunctionNames: false
+KeepEmptyLinesAtTheStartOfBlocks: true
+MaxEmptyLinesToKeep: 1
+NamespaceIndentation: None
+ObjCBlockIndentWidth: 2
+ObjCSpaceAfterProperty: false
+ObjCSpaceBeforeProtocolList: false
+PenaltyBreakBeforeFirstCallParameter: 1
+PenaltyBreakComment: 300
+PenaltyBreakFirstLessLess: 120
+PenaltyBreakString: 1000
+PenaltyExcessCharacter: 1000000
+PenaltyReturnTypeOnItsOwnLine: 200
+PointerAlignment: Left
+ReflowComments:  true
+SortIncludes:    true
+SpaceAfterCStyleCast: false
+SpaceBeforeAssignmentOperators: true
+SpaceBeforeParens: ControlStatements
+SpaceInEmptyParentheses: false
+SpacesBeforeTrailingComments: 2
+SpacesInAngles:  false
+SpacesInContainerLiterals: true
+SpacesInCStyleCastParentheses: false
+SpacesInParentheses: false
+SpacesInSquareBrackets: false
+Standard:        Cpp11
+TabWidth:        8
+UseTab:          Never
+...
+

--- a/bridge/cxx/gen_array_operations.py
+++ b/bridge/cxx/gen_array_operations.py
@@ -84,7 +84,7 @@ def main(args):
 #ifndef __BHXX_ARRAY_OPERATIONS_H
 #define __BHXX_ARRAY_OPERATIONS_H
 
-#include <bhxx/multi_array.hpp>
+#include <bhxx/bh_array.hpp>
 
 namespace bhxx {
 

--- a/bridge/cxx/include/bhxx/bh_array.hpp
+++ b/bridge/cxx/include/bhxx/bh_array.hpp
@@ -18,8 +18,8 @@ GNU Lesser General Public License along with Bohrium.
 If not, see <http://www.gnu.org/licenses/>.
 */
 
-#ifndef __BHXX_MULTI_ARRAY_H
-#define __BHXX_MULTI_ARRAY_H
+#ifndef __BHXX_BH_ARRAY_H
+#define __BHXX_BH_ARRAY_H
 
 #include "util.hpp"
 #include <bh_component.hpp>

--- a/bridge/cxx/include/bhxx/bh_array.hpp
+++ b/bridge/cxx/include/bhxx/bh_array.hpp
@@ -24,6 +24,7 @@ If not, see <http://www.gnu.org/licenses/>.
 #include "util.hpp"
 #include <bh_component.hpp>
 #include <bxx/traits.hpp>
+#include <memory>
 #include <ostream>
 #include <vector>
 
@@ -88,6 +89,14 @@ class BhArray {
     // Pretty printing the content of the array
     // TODO: for now it always print the flatten array
     void pprint(std::ostream& os) const;
+
+    //@{
+    /** Obtain the data pointer of the base array.
+     *  \note This pointer might be a nullptr if the data in
+     *        the base is not yet initialised */
+    const T* data() const { return static_cast<T*>(base->base->data); }
+    T*       data() { return static_cast<T*>(base->base->data); }
+    //@}
 };
 
 template <typename T>

--- a/bridge/cxx/include/bhxx/bhxx.hpp
+++ b/bridge/cxx/include/bhxx/bhxx.hpp
@@ -24,8 +24,8 @@ If not, see <http://www.gnu.org/licenses/>.
 #ifndef __BHXX_H
 #define __BHXX_H
 
-#include "multi_array.hpp"
-#include "runtime.hpp"
 #include <bhxx/array_operations.hpp>
+#include <bhxx/bh_array.hpp>
+#include <bhxx/runtime.hpp>
 
 #endif

--- a/bridge/cxx/include/bhxx/bhxx.hpp
+++ b/bridge/cxx/include/bhxx/bhxx.hpp
@@ -24,9 +24,8 @@ If not, see <http://www.gnu.org/licenses/>.
 #ifndef __BHXX_H
 #define __BHXX_H
 
-#include <bhxx/array_operations.hpp>
 #include "multi_array.hpp"
 #include "runtime.hpp"
-
+#include <bhxx/array_operations.hpp>
 
 #endif

--- a/bridge/cxx/include/bhxx/multi_array.hpp
+++ b/bridge/cxx/include/bhxx/multi_array.hpp
@@ -21,37 +21,35 @@ If not, see <http://www.gnu.org/licenses/>.
 #ifndef __BHXX_MULTI_ARRAY_H
 #define __BHXX_MULTI_ARRAY_H
 
-
-#include <vector>
-#include <ostream>
+#include "util.hpp"
 #include <bh_component.hpp>
 #include <bxx/traits.hpp>
-#include "util.hpp"
+#include <ostream>
+#include <vector>
 
 namespace bhxx {
-
 
 // The base underlying (multiple) arrays
 template <typename T>
 class BhBase {
-public:
-    // NB: `base` must survive until the next flush and not when the `BhBase` object is freed
-    bh_base *base;
+  public:
+    // NB: `base` must survive until the next flush and not when the `BhBase` object is
+    // freed
+    bh_base*  base;
     typedef T scalar_type;
-    BhBase(size_t nelem) : base(new bh_base()){
-        base->data = nullptr;
+    BhBase(size_t nelem) : base(new bh_base()) {
+        base->data  = nullptr;
         base->nelem = nelem;
         bxx::assign_array_type<T>(base);
-//        std::cout << "Create base " << this << std::endl;
+        //        std::cout << "Create base " << this << std::endl;
     }
 
     ~BhBase();
 };
 
-
 template <typename T>
 class BhArray {
-public:
+  public:
     // The data type of each array element
     typedef T scalar_type;
     // The array offset (from the start of the base in number of elements)
@@ -61,49 +59,43 @@ public:
     // The array stride (the absolute stride of each dimension in number of elements)
     Stride stride;
     // Pointer to the base of this array
-    std::shared_ptr<BhBase<T> > base;
+    std::shared_ptr<BhBase<T>> base;
 
     // Create a new view that points to a new base
-    BhArray(const Shape &shape, const Stride &stride, const size_t offset = 0) :
-            offset(offset),
+    BhArray(const Shape& shape, const Stride& stride, const size_t offset = 0)
+          : offset(offset),
             shape(shape),
             stride(stride),
             base(new BhBase<T>(shape.prod())) {}
 
     // Create a new view that points to a new base (contiguous stride, row-major)
-    BhArray(const Shape &shape, const size_t offset = 0) :
-            offset(offset),
+    BhArray(const Shape& shape, const size_t offset = 0)
+          : offset(offset),
             shape(shape),
             stride(contiguous_stride(shape)),
             base(new BhBase<T>(shape.prod())) {}
 
     // Create a view that points to the given base
-    BhArray(const std::shared_ptr<BhBase<T> > &base, const Shape &shape,
-            const Stride &stride, const size_t offset = 0) :
-            offset(offset),
-            shape(shape),
-            stride(stride),
-            base(base) {}
+    BhArray(const std::shared_ptr<BhBase<T>>& base, const Shape& shape,
+            const Stride& stride, const size_t offset = 0)
+          : offset(offset), shape(shape), stride(stride), base(base) {}
 
     // Create a view that points to the given base (contiguous stride, row-major)
-    BhArray(const std::shared_ptr<BhBase<T> > &base, const Shape &shape, const size_t offset = 0) :
-            offset(offset),
-            shape(shape),
-            stride(contiguous_stride(shape)),
-            base(base) {}
+    BhArray(const std::shared_ptr<BhBase<T>>& base, const Shape& shape,
+            const size_t offset = 0)
+          : offset(offset), shape(shape), stride(contiguous_stride(shape)), base(base) {}
 
     // Pretty printing the content of the array
     // TODO: for now it always print the flatten array
     void pprint(std::ostream& os) const;
 };
 
-
 template <typename T>
-std::ostream& operator<< (std::ostream& os, const BhArray<T>& ary) {
+std::ostream& operator<<(std::ostream& os, const BhArray<T>& ary) {
     ary.pprint(os);
     return os;
 }
 
-} // namespace bhxx
+}  // namespace bhxx
 
 #endif

--- a/bridge/cxx/include/bhxx/runtime.hpp
+++ b/bridge/cxx/include/bhxx/runtime.hpp
@@ -36,15 +36,20 @@ namespace bhxx {
  */
 class Runtime {
   private:
-    std::vector<bh_instruction> instr_list;  // The lazy evaluated instructions
-    std::vector<bh_base*> free_list;  // The bases that has to freed at the next flush
+    // The lazy evaluated instructions
+    std::vector<bh_instruction> instr_list;
 
-    bohrium::ConfigParser config;  // Bohrium Configuration
-    bohrium::component::ComponentFace
-          runtime;  // The Bohrium Runtime i.e. the child of this component
+    // The bases that has to freed at the next flush
+    std::vector<bh_base*> free_list;
 
-    std::map<std::string, bh_opcode>
-           extmethods;                // Mapping an extension method name to an opcode id
+    // Bohrium Configuration
+    bohrium::ConfigParser config;
+
+    // The Bohrium Runtime i.e. the child of this component
+    bohrium::component::ComponentFace runtime;
+
+    // Mapping an extension method name to an opcode id
+    std::map<std::string, bh_opcode> extmethods;
     size_t extmethod_next_opcode_id;  // The opcode id for the next new extension method
 
     // Append instruction to the `instr_list`
@@ -94,9 +99,8 @@ class Runtime {
         instr_append_operand(instr, scalar);
         instr_append_operand(instr, ops...);
     }
-    // Create and enqueue a new bh_instruction based on `opcode` and a variadic pack of
-    // BhArrays
-    // and at most one scalar value
+    // Create and enqueue a new bh_instruction based on `opcode` and a variadic
+    // pack of BhArrays and at most one scalar value
     template <typename... Ts>
     void enqueue(bh_opcode opcode, Ts... ops) {
         bh_instruction instr;
@@ -122,8 +126,8 @@ class Runtime {
         instr_list_append(instr);
     }
 
-    // We have to handle free specially because it takes a `BhBase` and must maintain the
-    // `free_list`
+    // We have to handle free specially because it takes a `BhBase`
+    // and must maintain the `free_list`
     template <typename T>
     void enqueue_free(BhBase<T>& base) {
         bh_view view;
@@ -149,11 +153,10 @@ class Runtime {
         auto it = extmethods.find(name);
         if (it != extmethods.end()) {  // Got it
             opcode = it->second;
-        } else {  // Add it
+        } else {
+            // Add it and tell rest of Bohrium about this new extmethod
             opcode = extmethod_next_opcode_id++;
-            runtime.extmethod(
-                  name.c_str(),
-                  opcode);  // Tell the rest of Bohrium about this new extmethod
+            runtime.extmethod(name.c_str(), opcode);
             extmethods.insert(std::pair<std::string, bh_opcode>(name, opcode));
         }
 

--- a/bridge/cxx/include/bhxx/runtime.hpp
+++ b/bridge/cxx/include/bhxx/runtime.hpp
@@ -22,11 +22,9 @@ If not, see <http://www.gnu.org/licenses/>.
 #include <iostream>
 #include <sstream>
 
-#include "multi_array.hpp"
+#include "bh_array.hpp"
 #include <bh_component.hpp>
 #include <bh_instruction.hpp>
-
-#include "multi_array.hpp"
 
 namespace bhxx {
 

--- a/bridge/cxx/include/bhxx/runtime.hpp
+++ b/bridge/cxx/include/bhxx/runtime.hpp
@@ -22,14 +22,13 @@ If not, see <http://www.gnu.org/licenses/>.
 #include <iostream>
 #include <sstream>
 
+#include "multi_array.hpp"
 #include <bh_component.hpp>
 #include <bh_instruction.hpp>
-#include "multi_array.hpp"
 
 #include "multi_array.hpp"
 
 namespace bhxx {
-
 
 /**
  *  Encapsulation of communication with Bohrium runtime.
@@ -38,23 +37,26 @@ namespace bhxx {
  *  Note: Not thread-safe.
  */
 class Runtime {
-private:
-    std::vector<bh_instruction> instr_list;      // The lazy evaluated instructions
-    std::vector<bh_base*> free_list;             // The bases that has to freed at the next flush
+  private:
+    std::vector<bh_instruction> instr_list;  // The lazy evaluated instructions
+    std::vector<bh_base*> free_list;  // The bases that has to freed at the next flush
 
-    bohrium::ConfigParser config;                // Bohrium Configuration
-    bohrium::component::ComponentFace runtime;   // The Bohrium Runtime i.e. the child of this component
+    bohrium::ConfigParser config;  // Bohrium Configuration
+    bohrium::component::ComponentFace
+          runtime;  // The Bohrium Runtime i.e. the child of this component
 
-    std::map<std::string, bh_opcode> extmethods; // Mapping an extension method name to an opcode id
-    size_t extmethod_next_opcode_id;             // The opcode id for the next new extension method
+    std::map<std::string, bh_opcode>
+           extmethods;                // Mapping an extension method name to an opcode id
+    size_t extmethod_next_opcode_id;  // The opcode id for the next new extension method
 
     // Append instruction to the `instr_list`
-    void instr_list_append(bh_instruction &instr);
+    void instr_list_append(bh_instruction& instr);
 
-public:
-    Runtime() : config(-1), // stack level -1 is the bridge
-                runtime(config.getChildLibraryPath(), 0), // and child is stack level 0
-                extmethod_next_opcode_id(BH_MAX_OPCODE_ID+1) {}
+  public:
+    Runtime()
+          : config(-1),                                // stack level -1 is the bridge
+            runtime(config.getChildLibraryPath(), 0),  // and child is stack level 0
+            extmethod_next_opcode_id(BH_MAX_OPCODE_ID + 1) {}
 
     // Get the singleton instance of the Runtime class
     static Runtime& instance() {
@@ -65,18 +67,18 @@ public:
     // `instr_append_operand()` append an operand to the list of instruction in `instr`
     // Variadic base case: appending one array
     template <typename T>
-    void instr_append_operand(bh_instruction &instr, BhArray<T> ary) {
+    void instr_append_operand(bh_instruction& instr, BhArray<T> ary) {
         bh_view view;
-        view.base = ary.base->base;
+        view.base  = ary.base->base;
         view.start = ary.offset;
-        view.ndim = ary.shape.size();
+        view.ndim  = ary.shape.size();
         std::copy(ary.shape.begin(), ary.shape.end(), &view.shape[0]);
         std::copy(ary.stride.begin(), ary.stride.end(), &view.stride[0]);
         instr.operand.push_back(view);
     }
     // Variadic base case: appending one scalar
     template <typename T>
-    void instr_append_operand(bh_instruction &instr, T scalar) {
+    void instr_append_operand(bh_instruction& instr, T scalar) {
         bh_view view;
         view.base = nullptr;
         instr.operand.push_back(view);
@@ -84,17 +86,18 @@ public:
     }
     // Variadic case: appending one array and continue
     template <typename T, typename... Ts>
-    void instr_append_operand(bh_instruction &instr, BhArray<T> ary, Ts... ops) {
+    void instr_append_operand(bh_instruction& instr, BhArray<T> ary, Ts... ops) {
         instr_append_operand(instr, ary);
         instr_append_operand(instr, ops...);
     }
     // Variadic case: appending one scalar and continue
     template <typename T, typename... Ts>
-    void instr_append_operand(bh_instruction &instr, T scalar, Ts... ops) {
+    void instr_append_operand(bh_instruction& instr, T scalar, Ts... ops) {
         instr_append_operand(instr, scalar);
         instr_append_operand(instr, ops...);
     }
-    // Create and enqueue a new bh_instruction based on `opcode` and a variadic pack of BhArrays
+    // Create and enqueue a new bh_instruction based on `opcode` and a variadic pack of
+    // BhArrays
     // and at most one scalar value
     template <typename... Ts>
     void enqueue(bh_opcode opcode, Ts... ops) {
@@ -105,7 +108,7 @@ public:
     }
 
     // We have to handle random specially because of the `BH_R123` scalar type
-    void enqueue_random(BhArray<uint64_t> &out, uint64_t seed, uint64_t key) {
+    void enqueue_random(BhArray<uint64_t>& out, uint64_t seed, uint64_t key) {
         bh_instruction instr;
         instr.opcode = BH_RANDOM;
         // Append the output array
@@ -115,20 +118,21 @@ public:
         bh_view view;
         view.base = nullptr;
         instr.operand.push_back(view);
-        instr.constant.type = BH_R123;
+        instr.constant.type             = BH_R123;
         instr.constant.value.r123.start = seed;
         instr.constant.value.r123.key   = key;
         instr_list_append(instr);
     }
 
-    // We have to handle free specially because it takes a `BhBase` and must maintain the `free_list`
-    template<typename T>
-    void enqueue_free(BhBase<T> &base) {
+    // We have to handle free specially because it takes a `BhBase` and must maintain the
+    // `free_list`
+    template <typename T>
+    void enqueue_free(BhBase<T>& base) {
         bh_view view;
-        view.base = base.base;
-        view.start = 0;
-        view.ndim = 1;
-        view.shape[0] = base.base->nelem;
+        view.base      = base.base;
+        view.start     = 0;
+        view.ndim      = 1;
+        view.shape[0]  = base.base->nelem;
         view.stride[0] = 1;
         bh_instruction instr;
         instr.opcode = BH_FREE;
@@ -138,17 +142,20 @@ public:
     }
 
     // Enqueue an extension method
-    template<typename T>
-    void enqueue_extmethod(const std::string& name, BhArray<T> &out, BhArray<T> &in1, BhArray<T> &in2) {
+    template <typename T>
+    void enqueue_extmethod(const std::string& name, BhArray<T>& out, BhArray<T>& in1,
+                           BhArray<T>& in2) {
         bh_opcode opcode;
 
         // Look for the extension opcode
         auto it = extmethods.find(name);
-        if (it != extmethods.end()) {   // Got it
+        if (it != extmethods.end()) {  // Got it
             opcode = it->second;
-        } else {                        // Add it
+        } else {  // Add it
             opcode = extmethod_next_opcode_id++;
-            runtime.extmethod(name.c_str(), opcode); // Tell the rest of Bohrium about this new extmethod
+            runtime.extmethod(
+                  name.c_str(),
+                  opcode);  // Tell the rest of Bohrium about this new extmethod
             extmethods.insert(std::pair<std::string, bh_opcode>(name, opcode));
         }
 
@@ -159,10 +166,7 @@ public:
     // Send enqueued instructions to Bohrium for execution
     void flush();
 
-    ~Runtime() {
-        flush();
-    }
+    ~Runtime() { flush(); }
 };
-
 }
 #endif

--- a/bridge/cxx/include/bhxx/util.hpp
+++ b/bridge/cxx/include/bhxx/util.hpp
@@ -24,23 +24,21 @@ If not, see <http://www.gnu.org/licenses/>.
 #ifndef __BHXX_UTIL_H
 #define __BHXX_UTIL_H
 
-#include <vector>
-#include <numeric>
-#include <functional>
 #include <bh_view.hpp>
+#include <functional>
+#include <numeric>
+#include <vector>
 
 namespace bhxx {
 
 template <typename T, std::size_t MaxLength>
 struct SVector : public std::vector<T> {
-public:
+  public:
     using std::vector<T>::vector;
-    SVector(const std::vector<T> &other) : SVector(other.begin(), other.end()) {}
+    SVector(const std::vector<T>& other) : SVector(other.begin(), other.end()) {}
     SVector() = default;
 
-    T sum() const {
-        return std::accumulate(this->begin(), this->end(), T{0});
-    }
+    T sum() const { return std::accumulate(this->begin(), this->end(), T{0}); }
     T prod() const {
         return std::accumulate(this->begin(), this->end(), T{1}, std::multiplies<T>());
     }
@@ -48,12 +46,11 @@ public:
 
 // Some common SVectors
 typedef SVector<int64_t, BH_MAXDIM> Stride;
-typedef SVector<size_t, BH_MAXDIM> Shape;
-
+typedef SVector<size_t, BH_MAXDIM>  Shape;
 
 // Return a contiguous stride (row-major) based on `shape`
-Stride contiguous_stride(const Shape &shape);
+Stride contiguous_stride(const Shape& shape);
 
-} // namespace bhxx
+}  // namespace bhxx
 
 #endif

--- a/bridge/cxx/src/bh_array.cpp
+++ b/bridge/cxx/src/bh_array.cpp
@@ -36,13 +36,13 @@ template <typename T>
 void BhArray<T>::pprint(std::ostream& os) const {
 
     // Let's makes sure that the data we are reading is contiguous
-    BhArray<T> contiguous = BhArray<T>(shape);
+    BhArray<T> contiguous{shape};
     identity(contiguous, *this);
     sync(contiguous);
     Runtime::instance().flush();
 
     // Get the data pointer and check for NULL
-    const T* data = static_cast<T*>(contiguous.base->base->data);
+    const T* data = contiguous.data();
     if (data == nullptr) {
         os << "[<Uninitiated>]" << endl;
         return;

--- a/bridge/cxx/src/bh_array.cpp
+++ b/bridge/cxx/src/bh_array.cpp
@@ -18,21 +18,21 @@ GNU Lesser General Public License along with Bohrium.
 If not, see <http://www.gnu.org/licenses/>.
 */
 
-#include <bhxx/multi_array.hpp>
-#include <bhxx/runtime.hpp>
 #include <bhxx/array_operations.hpp>
+#include <bhxx/bh_array.hpp>
+#include <bhxx/runtime.hpp>
 
 using namespace std;
 
 namespace bhxx {
 
-template<typename T>
+template <typename T>
 inline BhBase<T>::~BhBase() {
-//    cout << "Delete base " << this << endl;
+    //    cout << "Delete base " << this << endl;
     Runtime::instance().enqueue_free(*this);
 }
 
-template<typename T>
+template <typename T>
 void BhArray<T>::pprint(std::ostream& os) const {
 
     // Let's makes sure that the data we are reading is contiguous
@@ -51,7 +51,7 @@ void BhArray<T>::pprint(std::ostream& os) const {
     // Pretty print the content
     os << scientific;
     os << "[";
-    for(size_t i=0; i < static_cast<size_t>(contiguous.base->base->nelem); ++i) {
+    for (size_t i = 0; i < static_cast<size_t>(contiguous.base->base->nelem); ++i) {
         if (i > 0) {
             os << ", ";
         }
@@ -60,8 +60,8 @@ void BhArray<T>::pprint(std::ostream& os) const {
     os << "]" << endl;
 }
 
-
-// Instantiate all possible types of `BhArray` and `BhBase`, which makes it possible to implement many of
+// Instantiate all possible types of `BhArray` and `BhBase`, which makes it possible to
+// implement many of
 // their methods here
 template class BhArray<bool>;
 template class BhArray<int8_t>;
@@ -74,8 +74,8 @@ template class BhArray<uint32_t>;
 template class BhArray<uint64_t>;
 template class BhArray<float>;
 template class BhArray<double>;
-template class BhArray<std::complex<float> >;
-template class BhArray<std::complex<double> >;
+template class BhArray<std::complex<float>>;
+template class BhArray<std::complex<double>>;
 template class BhBase<bool>;
 template class BhBase<int8_t>;
 template class BhBase<int16_t>;
@@ -87,8 +87,7 @@ template class BhBase<uint32_t>;
 template class BhBase<uint64_t>;
 template class BhBase<float>;
 template class BhBase<double>;
-template class BhBase<std::complex<float> >;
-template class BhBase<std::complex<double> >;
+template class BhBase<std::complex<float>>;
+template class BhBase<std::complex<double>>;
 
-
-} // namespace bhxx
+}  // namespace bhxx


### PR DESCRIPTION
Please review especially the changes introduced by employing `clang-format` in commit 4c8aaf1. I am happy to alter the formatting definition if this is wished by the maintainers.

The file `multi_array.hpp` has this name only for historical reasons and I suggest adopting the name `bh_array.hpp` instead.