### PR TITLE
Make where more robust

### DIFF
--- a/test/python/tests/test_mask.py
+++ b/test/python/tests/test_mask.py
@@ -18,6 +18,14 @@ class test_set_bool_mask_scalar:
         cmd += "res[m] = %s(42)" % dtype
         return cmd
 
+    def test_set_scalar_nan(self, arg):
+        (cmd, dtype) = arg
+        if dtype in util.TYPES.FLOAT:
+            cmd += "res[m] = M.nan"
+        else:
+            cmd = "res = 0"
+        return cmd
+
 
 class test_set_bool_mask:
     def init(self):

--- a/test/python/tests/test_mask.py
+++ b/test/python/tests/test_mask.py
@@ -60,6 +60,11 @@ class test_where:
                 cmd += "m = R.random_integers(0, 1, size=a.shape, dtype=np.bool, bohrium=BH); "
                 yield (cmd, dtype)
 
+    def test_scalar_condition(self, arg):
+        (cmd, dtype) = arg
+        cmd += "res = M.where(%s(True), a, b)" % dtype
+        return cmd
+
     def test_scalar1(self, arg):
         (cmd, dtype) = arg
         cmd += "res = M.where(m, %s(42), a)" % dtype
@@ -75,7 +80,7 @@ class test_where:
         cmd += "res = M.where(m, a, b)"
         return cmd
 
-    def test_nanarray(self, arg):
+    def test_nan_array(self, arg):
         (cmd, dtype) = arg
         if dtype in util.TYPES.FLOAT:
             cmd += "a[0] = M.nan;"
@@ -83,3 +88,13 @@ class test_where:
             return cmd
         else:
             return "res = 0"
+
+    def test_nan_scalar1(self, arg):
+        (cmd, dtype) = arg
+        cmd += "res = M.where(m, M.nan, a)"
+        return cmd
+
+    def test_nan_scalar2(self, arg):
+        (cmd, dtype) = arg
+        cmd += "res = M.where(m, a, M.nan)"
+        return cmd


### PR DESCRIPTION
- Add tests for scalar ``nan`` values in ``bh.where()``
- Add tests for scalar conditions in ``bh.where()``
- Fix #367 and add problem as a test
- Add shortcut in ``bh.where()`` for quasi-scalar inputs (arrays containing one element)