### PR TITLE
Use color define

### DIFF
--- a/include/colors.hpp
+++ b/include/colors.hpp
@@ -7,17 +7,21 @@
 //   std::cout << RED << "My red message" << RST << std::endl;
 // Remember to issue RST to reset color.
 
-#define RST (isatty(1) ? "\x1B[0m" : "")
+#ifndef USE_COLORS
+#define USE_COLORS isatty(1)
+#endif
 
-#define RED (isatty(1) ? "\x1B[31m" : "")
-#define GRN (isatty(1) ? "\x1B[32m" : "")
-#define YEL (isatty(1) ? "\x1B[33m" : "")
-#define BLU (isatty(1) ? "\x1B[34m" : "")
-#define MAG (isatty(1) ? "\x1B[35m" : "")
-#define CYN (isatty(1) ? "\x1B[36m" : "")
-#define WHT (isatty(1) ? "\x1B[37m" : "")
+#define RST (USE_COLORS ? "\x1B[0m" : "")
 
-#define BOLD (isatty(1) ? "\x1B[1m" : "")
-#define UNDL (isatty(1) ? "\x1B[4m" : "")
+#define RED (USE_COLORS ? "\x1B[31m" : "")
+#define GRN (USE_COLORS ? "\x1B[32m" : "")
+#define YEL (USE_COLORS ? "\x1B[33m" : "")
+#define BLU (USE_COLORS ? "\x1B[34m" : "")
+#define MAG (USE_COLORS ? "\x1B[35m" : "")
+#define CYN (USE_COLORS ? "\x1B[36m" : "")
+#define WHT (USE_COLORS ? "\x1B[37m" : "")
+
+#define BOLD (USE_COLORS ? "\x1B[1m" : "")
+#define UNDL (USE_COLORS ? "\x1B[4m" : "")
 
 #endif  // __COLORS


### PR DESCRIPTION
Actually fixes #364

Now you can add `-DCMAKE_CXX_FLAGS="-DUSE_COLOR=1"` when running CMake to force the use of color no matter if tty or not.