### PR TITLE
Disable the effect of %%bohrium if bohrium cannot be imported.

### DIFF
--- a/ipython-magic.py
+++ b/ipython-magic.py
@@ -8,23 +8,39 @@
 #    print(numpy.arange(10))
 ####################################
 from IPython.core.magic import register_cell_magic
-import bohrium
 
-@bohrium.replace_numpy
-def execute(__code):
-    exec(__code, globals(), locals())
-    __excludes = set(["__excludes", "__code", "np", "bohrium"])
+try:
+    import bohrium
 
-    try:
-        # Python 2.x
-        for key, value in locals().iteritems():
-            if key not in __excludes:
-                globals()[key] = value
-    except:
-        # Python 3.x
-        for key, value in locals().items():
-            if key not in __excludes:
-                globals()[key] = value
+    have_bohrium = True
+
+    @bohrium.replace_numpy
+    def execute(__code):
+        exec(__code, globals(), locals())
+        __excludes = set(["__excludes", "__code", "np", "bohrium"])
+
+        try:
+            # Python 2.x
+            for key, value in locals().iteritems():
+                if key not in __excludes:
+                    globals()[key] = value
+        except:
+            # Python 3.x
+            for key, value in locals().items():
+                if key not in __excludes:
+                    globals()[key] = value
+except ImportError:
+    warning_shown = False # Warning about missin bohrium has been shown
+
+    def execute(__code):
+        global warning_shown
+
+        if not warning_shown:
+            print("WARNING: Module bohrium could not be imported.\n"
+                  "         The magic command '%%bohrium' will have no effect.")
+            warning_shown = True
+
+        exec(__code, globals())
 
 
 @register_cell_magic


### PR DESCRIPTION
The first time the user attempts to use `%%bohrium` a warning will be shown. From this point onwards all `%%bohrium` statements will have no effect.