### PR TITLE
Includes Nd convolve and correlate

### DIFF
--- a/bridge/npbackend/bohrium/__init__.py
+++ b/bridge/npbackend/bohrium/__init__.py
@@ -31,11 +31,14 @@ from . import bh_info
 from . import interop_pyopencl
 from . import interop_numpy
 from . import backend_messaging
-from .signal import convolve, correlate, correlate1d, convolve1d
 from .nobh import bincount
 
-from numpy_force import dtype
+# In NumPy `correlate` and `convolve` only handles 1D arrays whereas in SciPy they handles ND arrays.
+# However, NumPy and SciPy's functionality differ! Thus, the ND version cannot replace NumPy's 1D version.
+from .signal import correlate1d as correlate, convolve1d as convolve
+from .signal import correlate as correlate_scipy, convolve as convolve_scipy
 
+from numpy_force import dtype
 asarray = array
 asanyarray = array
 

--- a/bridge/npbackend/bohrium/__init__.py
+++ b/bridge/npbackend/bohrium/__init__.py
@@ -31,8 +31,7 @@ from . import bh_info
 from . import interop_pyopencl
 from . import interop_numpy
 from . import backend_messaging
-from .signal import convolve1d as convolve
-from .signal import correlate1d as correlate
+from .signal import convolve, correlate, correlate1d, convolve1d
 from .nobh import bincount
 
 from numpy_force import dtype

--- a/bridge/npbackend/bohrium/random123.pyx
+++ b/bridge/npbackend/bohrium/random123.pyx
@@ -7,6 +7,7 @@ Random functions
 """
 import bohrium as np
 import numpy_force as numpy
+from numpy_force.random import mtrand # Expose the mersenne twister API (not accelerated by Bohrium)
 import operator
 import functools
 import datetime

--- a/bridge/npbackend/bohrium/signal.py
+++ b/bridge/npbackend/bohrium/signal.py
@@ -167,9 +167,23 @@ def _findValid(Array, FilterSize):
 
 
 def _invertArr(Array):
-    # Returns a view of array with all dimensions reversed
+    """Reverse all elements in each axis"""
+
+    def flip(m, axis):
+        """Copy of `numpy.flip()`, which were introduced in NumPy v1.12"""
+        if not hasattr(m, 'ndim'):
+            m = array_create.array(m)
+        indexer = [slice(None)] * m.ndim
+        try:
+            indexer[axis] = slice(None, None, -1)
+        except IndexError:
+            raise ValueError("axis=%i is invalid for the %i-dimensional input array"
+                             % (axis, m.ndim))
+        return m[tuple(indexer)]
+
+    # Flip all axises
     for i in range(len(Array.shape)):
-        Array = np.flip(Array, axis=i)
+        Array = flip(Array, axis=i)
     return Array
 
 
@@ -236,7 +250,7 @@ def convolve(a, v, mode='full'):
     if not bhary.check(a) and not bhary.check(v):
         raise TypeError("convolveNd: Expects Bohrium arrays")
 
-    if (a.size>v.size) or (mode=='same'):
+    if (a.size > v.size) or (mode == 'same'):
         Array = a
         Filter = _invertArr(v)
     else:
@@ -250,7 +264,7 @@ def correlate(a, v, mode='valid'):
     if not bhary.check(a) and not bhary.check(v):
         raise TypeError("correlateNd: Expects Bohrium arrays")
 
-    if (a.size>v.size) or (mode=='same'):
+    if (a.size > v.size) or (mode == 'same'):
         Array = a
         Filter = v
     else:

--- a/bridge/npbackend/bohrium/signal.py
+++ b/bridge/npbackend/bohrium/signal.py
@@ -236,7 +236,7 @@ def convolve(a, v, mode='full'):
     if not bhary.check(a) and not bhary.check(v):
         raise TypeError("convolveNd: Expects Bohrium arrays")
 
-    if a.size > v.size:
+    if (a.size>v.size) or (mode=='same'):
         Array = a
         Filter = _invertArr(v)
     else:
@@ -250,7 +250,7 @@ def correlate(a, v, mode='valid'):
     if not bhary.check(a) and not bhary.check(v):
         raise TypeError("correlateNd: Expects Bohrium arrays")
 
-    if a.size > v.size:
+    if (a.size>v.size) or (mode=='same'):
         Array = a
         Filter = v
     else:

--- a/bridge/npbackend/bohrium/signal.py
+++ b/bridge/npbackend/bohrium/signal.py
@@ -5,6 +5,7 @@ Signal Processing
 Common signal processing functions, which often handle multiple dimension
 
 """
+import bohrium as np
 import numpy_force as numpy
 from numpy_force.lib.stride_tricks import as_strided
 from . import array_create
@@ -12,7 +13,8 @@ from . import bhary
 from . import ufuncs
 from . import linalg
 
-
+# 1d
+#---------------------------------------------------------------------------------
 def _correlate_and_convolve_body(vector, filter, d, mode):
     """ The body of correlate() and convolve() are identical"""
 
@@ -72,7 +74,7 @@ def convolve1d(a, v, mode='full'):
 
     # Let's make sure that we are working on Bohrium arrays
     if not bhary.check(a) and not bhary.check(v):
-        return numpy.correlate(a, v, mode)
+        return numpy.convolve(a, v, mode)
     else:
         a = array_create.array(a)
         v = array_create.array(v)
@@ -86,3 +88,163 @@ def convolve1d(a, v, mode='full'):
         filter = v[::-1]
     d = int((filter.size - 1) / 2)
     return _correlate_and_convolve_body(vector, filter, d, mode)
+ 
+# Nd
+#---------------------------------------------------------------------------------
+def _findIndices(ArrSize,FilterSize):
+    N=FilterSize.shape[0]
+    n=int(FilterSize.prod())
+    CumSizeArr=np.ones([N],dtype=np.int32)
+    CumSizeArr[1:N]=ArrSize[0:N-1].cumprod()
+    CumSize=np.ones([N],dtype=np.int32)
+    CumSize[1:N]=FilterSize[0:N-1].cumprod()
+    
+    vals=np.empty((n,N),dtype=np.int32)
+    for i in range(N):
+        vals[:,i]=np.linspace(0,n-1,n)
+
+    vals=ufuncs.floor(vals/CumSize)
+    vals=vals%FilterSize
+    CurrPos=np.sum(vals*CumSizeArr,axis=1)
+    
+    return CurrPos.astype(np.int32)
+
+def _addZerosNd(Array,FilterSize,dtype):
+    # Introduces zero padding for Column major flattening
+    PaddedSize=np.asarray(Array.shape,dtype=np.int32)
+    N=FilterSize.shape[0]
+    PaddedSize[0:N]+=FilterSize-1
+    cut='['
+    for i in range(PaddedSize.shape[0]):
+        if i<N:
+            minpos=int(FilterSize[i]/2)
+            maxpos=Array.shape[i]+int(FilterSize[i]/2)
+        else:
+            minpos=0
+            maxpos=Array.shape[i]
+        cut+=str(minpos)+':'+str(maxpos)+','
+    cut=cut[:-1]+']'
+    Padded=np.zeros(PaddedSize,dtype=dtype)
+    exec('Padded'+cut+'=Array')
+    return Padded
+
+def _findSame(Array,FilterSize):
+    # Numpy convention. Returns view of the same size as the largest input
+    N=FilterSize.shape[0]
+    cut='['
+    for i in range(len(Array.shape)):
+        if i<N:
+            minpos=(FilterSize[i]-1)//2
+            maxpos=Array.shape[i]-(FilterSize[i])//2
+        else:
+            minpos=0
+            maxpos=Array.shape[i]
+        cut+=str(minpos)+':'+str(maxpos)+','
+    cut=cut[:-1]+']'
+    res=eval('Array'+cut)
+    return res
+
+def _findValid(Array,FilterSize):
+    # Cuts the result down to only totally overlapping views
+    N=FilterSize.shape[0]
+    cut='['
+    for i in range(len(Array.shape)):
+        if i<N:
+            minpos=FilterSize[i]-1
+            maxpos=Array.shape[i]-FilterSize[i]+1
+        else:
+            minpos=0
+            maxpos=Array.shape[i]
+        cut+=str(minpos)+':'+str(maxpos)+','
+    cut=cut[:-1]+']'
+    res=eval('Array'+cut)
+    return res
+
+def _invertArr(Array):
+    # Returns a view of array with all dimensions reversed
+    for i in range(len(Array.shape)):
+        Array=np.flip(Array,axis=i)
+    return Array
+
+def _correlate_kernel(Array,Filter,mode):
+    # Anything to do?
+    if Array.size <= 0:
+        return Array.copy()
+
+    # Complex correlate includes a conjugation
+    if numpy.iscomplexobj(Filter):
+        Filter = numpy.conj(Filter)
+    
+    # Get sizes as arrays for easier manipulation
+    ArrSize=np.asarray(Array.shape,dtype=np.int32)
+    FilterSize=np.asarray(Filter.shape,dtype=np.int32)
+
+    # Check that mode='valid' is allowed given the array sizes
+    if mode=='valid':
+        diffSize=ArrSize[:FilterSize.size]-FilterSize
+        nSmaller=np.sum(diffSize<0)
+        if nSmaller>0:
+            raise ValueError("correlateNd: For 'valid' mode, one must be at least as large as the other in every dimension")
+
+    # Use numpy convention for result dype
+    dtype = numpy.result_type(Array, Filter) 
+    
+    # Add zeros along relevant dimensions
+    Padded=_addZerosNd(Array,FilterSize,dtype)
+    PaddedSize=np.asarray(Padded.shape,dtype=np.int32)
+    
+    # Get positions of first view
+    IndiVec=_findIndices(PaddedSize,FilterSize)
+    CenterPos=tuple((FilterSize-1)//2)
+    IndiMat=IndiVec.reshape(FilterSize,order='F')
+    nPre=IndiMat[CenterPos] # Required zeros before Array for correct alignment
+    nPost=IndiVec[Filter.size-1]-nPre 
+    n=Padded.size
+    nTot=n+nPre+nPost # Total size after pre/post padding
+    V=np.empty([nTot],dtype=dtype)
+    V[nPre:n+nPre]=Padded.flatten(order='F')
+    V[:nPre]=0
+    V[n+nPre:]=0
+    A=Filter.flatten(order='F')
+    
+    # Actual correlation calculation
+    Correlated=np.empty([n],dtype=dtype)
+    Correlated=V[IndiVec[0]:n+IndiVec[0]]*A[0]
+    for i in range(1,Filter.size):
+        Correlated+=V[IndiVec[i]:n+IndiVec[i]]*A[i]
+    
+    Full=Correlated.reshape(PaddedSize,order='F')
+    if mode=='full':
+        return Full
+    elif mode=='same':
+        return _findSame(Full,FilterSize)
+    elif mode=='valid':
+        return _findValid(Full,FilterSize)
+    else:
+        raise ValueError("correlateNd: invalid mode '%s'" % mode)
+
+def convolveNd(a,v,mode='full'):
+    # Let's make sure that we are working on Bohrium arrays
+    if not bhary.check(a) and not bhary.check(v):
+        raise TypeError("convolveNd: Expects Bohrium arrays")
+        
+    if a.size>v.size:
+        Array=a
+        Filter=_invertArr(v)
+    else:
+        Array=v
+        Filter=_invertArr(a)
+    return _correlate_kernel(Array,Filter,mode)
+
+def correlateNd(a,v,mode='valid'):
+    # Let's make sure that we are working on Bohrium arrays
+    if not bhary.check(a) and not bhary.check(v):
+        raise TypeError("correlateNd: Expects Bohrium arrays")
+    
+    if a.size>v.size:
+        Array=a
+        Filter=v
+    else:
+        Array=_invertArr(v)
+        Filter=_invertArr(a)
+    return _correlate_kernel(Array,Filter,mode)

--- a/test/python/run.py
+++ b/test/python/run.py
@@ -109,9 +109,15 @@ def run(args):
                     # Let's execute the two commands
                     env = {"np": numpy, "bh": bohrium}
                     exec (cmd_np, env)
-                    assert (not bohrium.check(env['res']))
-
                     res_np = env['res']
+                    if bohrium.check(res_np):
+                        print("\n")
+                        print("%s  [Error]  The NumPy command returns a Bohrium array!%s" % (FAIL, ENDC))
+                        print("%s  [NP CMD] %s%s" % (OKBLUE, cmd_np, ENDC))
+                        print("%s  [NP RES]\n%s%s" % (OKGREEN, res_np, ENDC))
+                        if not args.cont_on_error:
+                            sys.exit(1)
+
                     env = {"np": numpy, "bh": bohrium}
                     exec (cmd_bh, env)
 

--- a/test/python/tests/test_signal.py
+++ b/test/python/tests/test_signal.py
@@ -1,7 +1,7 @@
 import util
 
 
-class test_vector:
+class test_1d:
     def init(self):
         for mode in ['same', 'valid', 'full']:
             for dtype in util.TYPES.FLOAT:
@@ -11,12 +11,26 @@ class test_vector:
                             cmd = "R = bh.random.RandomState(42); a=%s; v=%s;" % (cmd1, cmd2)
                             yield (cmd, mode)
 
+    def test_correlate1d(self, args):
+        (cmd, mode) = args
+        np_cmd = cmd + "res = M.correlate(a, v, mode='%s')" % mode
+        bh_cmd = cmd + "res = M.correlate1d(a, v, mode='%s')" % mode
+        return (np_cmd, bh_cmd)
+
+    def test_convolve1d(self, args):
+        (cmd, mode) = args
+        np_cmd = cmd + "res = M.convolve(a, v, mode='%s')" % mode
+        bh_cmd = cmd + "res = M.convolve1d(a, v, mode='%s')" % mode
+        return (np_cmd, bh_cmd)
+
     def test_correlate(self, args):
         (cmd, mode) = args
-        cmd += "res = M.correlate(a, v, mode='%s')" % mode
-        return cmd
+        np_cmd = cmd + "res = M.correlate(a, v, mode='%s')" % mode
+        bh_cmd = cmd + "res = M.correlate(a, v, mode='%s')" % mode
+        return (np_cmd, bh_cmd)
 
     def test_convolve(self, args):
         (cmd, mode) = args
-        cmd += "res = M.convolve(a, v, mode='%s')" % mode
-        return cmd
+        np_cmd = cmd + "res = M.convolve(a, v, mode='%s')" % mode
+        bh_cmd = cmd + "res = M.convolve(a, v, mode='%s')" % mode
+        return (np_cmd, bh_cmd)

--- a/test/python/tests/test_signal.py
+++ b/test/python/tests/test_signal.py
@@ -49,7 +49,7 @@ class _test_scipy:
     def test_convolve(self, args):
         (cmd, mode) = args
         scipy_cmd = cmd + "from scipy import signal; res = signal.convolve(a, v, mode='%s')" % mode
-        bh_cmd = cmd + "res = M.convolve_scipy(a, v, mode='%s')" % mode
+        bh_cmd = cmd + "res = bh.convolve_scipy(a, v, mode='%s')" % mode
         return (scipy_cmd, bh_cmd)
 
 try:

--- a/test/python/tests/test_signal.py
+++ b/test/python/tests/test_signal.py
@@ -11,26 +11,49 @@ class test_1d:
                             cmd = "R = bh.random.RandomState(42); a=%s; v=%s;" % (cmd1, cmd2)
                             yield (cmd, mode)
 
-    def test_correlate1d(self, args):
-        (cmd, mode) = args
-        np_cmd = cmd + "res = M.correlate(a, v, mode='%s')" % mode
-        bh_cmd = cmd + "res = M.correlate1d(a, v, mode='%s')" % mode
-        return (np_cmd, bh_cmd)
-
-    def test_convolve1d(self, args):
-        (cmd, mode) = args
-        np_cmd = cmd + "res = M.convolve(a, v, mode='%s')" % mode
-        bh_cmd = cmd + "res = M.convolve1d(a, v, mode='%s')" % mode
-        return (np_cmd, bh_cmd)
-
     def test_correlate(self, args):
         (cmd, mode) = args
-        np_cmd = cmd + "res = M.correlate(a, v, mode='%s')" % mode
-        bh_cmd = cmd + "res = M.correlate(a, v, mode='%s')" % mode
-        return (np_cmd, bh_cmd)
+        cmd += "res = M.correlate(a, v, mode='%s')" % mode
+        return cmd
 
     def test_convolve(self, args):
         (cmd, mode) = args
-        np_cmd = cmd + "res = M.convolve(a, v, mode='%s')" % mode
-        bh_cmd = cmd + "res = M.convolve(a, v, mode='%s')" % mode
-        return (np_cmd, bh_cmd)
+        cmd += "res = M.convolve(a, v, mode='%s')" % mode
+        return cmd
+
+
+class _test_scipy:
+    def init(self):
+        for mode in ['valid', 'full', 'same']:
+            for dtype in util.TYPES.FLOAT:
+                for cmd1, shape1 in util.gen_random_arrays("R", 3, min_ndim=1, max_dim=10, samples_in_each_ndim=1,
+                                                           dtype=dtype, no_views=True):
+                    if util.prod(shape1) <= 0:
+                        continue
+                    # Notice, the second shape must have the same number of dimension as the first one
+                    # and the max dimension cannot be larger than in the first shape
+                    # Finally, dimensions above 5 simple take too long
+                    max_dim = min(min(shape1), 5)
+                    for cmd2, shape2 in util.gen_random_arrays("R", len(shape1), min_ndim=len(shape1), max_dim=max_dim,
+                                                               samples_in_each_ndim=1, dtype=dtype, no_views=True):
+                        if util.prod(shape2) > 0:
+                            cmd = "R = bh.random.RandomState(42); a=%s; v=%s;" % (cmd1, cmd2)
+                            yield (cmd, mode)
+
+    def test_correlate(self, args):
+        (cmd, mode) = args
+        scipy_cmd = cmd + "from scipy import signal; res = signal.correlate(a, v, mode='%s')" % mode
+        bh_cmd = cmd + "res = M.correlate_scipy(a, v, mode='%s')" % mode
+        return (scipy_cmd, bh_cmd)
+
+    def test_convolve(self, args):
+        (cmd, mode) = args
+        scipy_cmd = cmd + "from scipy import signal; res = signal.convolve(a, v, mode='%s')" % mode
+        bh_cmd = cmd + "res = M.convolve_scipy(a, v, mode='%s')" % mode
+        return (scipy_cmd, bh_cmd)
+
+try:
+    import scipy
+    test_scipy = _test_scipy
+except ImportError:
+    print("SciPy not found, skipping the multidimensional tests of convolve() and correlate()")

--- a/test/python/util.py
+++ b/test/python/util.py
@@ -29,7 +29,10 @@ def gen_shapes(max_ndim, max_dim, iters=0, min_ndim=1):
 
             for _ in range(iters):
                 for d in range(len(shape)):
-                    shape[d] = np.random.randint(1, max_dim)
+                    if max_dim == 1:
+                        shape[d] = 1
+                    else:
+                        shape[d] = np.random.randint(1, max_dim)
                 yield shape
         else:
             finished = False

--- a/test/python/util.py
+++ b/test/python/util.py
@@ -134,3 +134,8 @@ def gen_random_arrays(random_state_name, max_ndim, max_dim=30, min_ndim=1, sampl
                 if sub not in sub_tried:
                     yield ("%s%s" % (cmd, sub), vshape)
                     sub_tried.add(sub)
+
+
+def prod(a):
+    """Returns the product of the elements in `a`"""
+    return functools.reduce(operator.mul, a)


### PR DESCRIPTION
Behaves as scipy.signal.convolve/correlate except when using mode='same'. mode='same' returns an array of the same size as the largest input. This behavior is similar to numpy.