### PR TITLE
Create new opcode (BH_CONJ) for computing complex conjugates

### DIFF
--- a/bridge/npbackend/bohrium/__init__.py
+++ b/bridge/npbackend/bohrium/__init__.py
@@ -61,7 +61,8 @@ for _name, _f in UFUNCS.items():
 # Aliases
 _aliases = [
     ('abs', 'absolute'),
-    ('round', 'round_')
+    ('round', 'round_'),
+    ('conjugate', 'conj')
 ]
 for _f, _t in _aliases:
     exec ("%s = %s" % (_f, _t))

--- a/bridge/npbackend/src/_bh.c
+++ b/bridge/npbackend/src/_bh.c
@@ -690,6 +690,10 @@ static PyObject* BhArray_all(PyObject *self, PyObject *args, PyObject *kwds) {
     return method2function("all", self, args, kwds);
 }
 
+static PyObject* BhArray_conj(PyObject *self, PyObject *args, PyObject *kwds) {
+    return method2function("conj", self, args, kwds);
+}
+
 static PyObject* BhArray_min(PyObject *self, PyObject *args, PyObject *kwds) {
     return method2function("min", self, args, kwds);
 }
@@ -748,6 +752,8 @@ static PyMethodDef BhArrayMethods[] = {
     {"cumprod",            (PyCFunction) BhArray_cumprod,       METH_VARARGS | METH_KEYWORDS, "a.cumprod(axis=None, dtype=None, out=None)\n\nReturn the cumulative product of the array elements over the given axis\n\nRefer to `numpy.cumprod` for full documentation."},
     {"any",                (PyCFunction) BhArray_any,           METH_VARARGS | METH_KEYWORDS, "a.any(axis=None, out=None)\n\nTest whether any array element along a given axis evaluates to True.\n\nRefer to `numpy.any` for full documentation."},
     {"all",                (PyCFunction) BhArray_all,           METH_VARARGS | METH_KEYWORDS, "a.all(axis=None, out=None)\n\nTest whether all array elements along a given axis evaluate to True.\n\nRefer to `numpy.all` for full documentation."},
+    {"conj",               (PyCFunction) BhArray_conj,          METH_VARARGS | METH_KEYWORDS, "a.conj(x[, out])\n\nReturn the complex conjugate, element-wise.\n\nRefer to `numpy.conj` for full documentation."},
+    {"conjugate",          (PyCFunction) BhArray_conj,          METH_VARARGS | METH_KEYWORDS, "a.conjugate(x[, out])\n\nReturn the complex conjugate, element-wise.\n\nRefer to `numpy.conj` for full documentation."},
     {"min",                (PyCFunction) BhArray_min,           METH_VARARGS | METH_KEYWORDS, "a.min(axis=None, out=None)\n\nReturn the minimum along a given axis.\n\nRefer to numpy.amin for full documentation."},
     {"max",                (PyCFunction) BhArray_max,           METH_VARARGS | METH_KEYWORDS, "a.max(axis=None, out=None)\n\nReturn the maximum along a given axis.\n\nRefer to numpy.amax for full documentation."},
     {"argmin",             (PyCFunction) BhArray_argmin,        METH_VARARGS | METH_KEYWORDS, "a.argmin(axis=None, out=None)\n\nReturns the indices of the minimum values along an axis.\n\nRefer to numpy.argmin for full documentation."},

--- a/core/codegen/opcodes.json
+++ b/core/codegen/opcodes.json
@@ -2175,5 +2175,25 @@
     "reduction":     false,
     "accumulate":    false,
     "system_opcode": false
+},
+{
+    "opcode": "BH_CONJ",
+    "doc":  "Complex conjugates.",
+    "code": "op1 = bh_conj(op2)",
+    "id":   "85",
+    "nop":   2,
+    "types": [
+            [ "BH_COMPLEX64", "BH_COMPLEX64" ],
+            [ "BH_COMPLEX128", "BH_COMPLEX128" ]
+    ],
+    "layout": [
+             [ "A", "A" ],
+             [ "A", "K" ]
+    ],
+    "elementwise":   true,
+    "composite":     false,
+    "reduction":     false,
+    "accumulate":    false,
+    "system_opcode": false
 }
 ]

--- a/core/jitk/instruction.cpp
+++ b/core/jitk/instruction.cpp
@@ -254,6 +254,9 @@ void write_operation(const bh_instruction &instr, const vector<string> &ops, str
             }
             break;
         }
+        case BH_CONJ:
+            out << ops[0] << " = conj(" << ops[1] << ");\n";
+            break;
         case BH_RANGE:
             out << ops[0] << " = " << ops[1] << ";\n";
             break;

--- a/core/jitk/instruction.cpp
+++ b/core/jitk/instruction.cpp
@@ -255,7 +255,12 @@ void write_operation(const bh_instruction &instr, const vector<string> &ops, str
             break;
         }
         case BH_CONJ:
-            out << ops[0] << " = conj(" << ops[1] << ");\n";
+            if (opencl) {
+                out << ops[0] << " = " << ops[1] << ";\n";
+                out << ops[0] << ".y *= -1;\n";
+            } else {
+                out << ops[0] << " = conj(" << ops[1] << ");\n";
+            }
             break;
         case BH_RANGE:
             out << ops[0] << " = " << ops[1] << ";\n";

--- a/test/python/tests/test_complex.py
+++ b/test/python/tests/test_complex.py
@@ -18,4 +18,14 @@ class test_complex_views:
     def test_imag(self, cmd):
         return cmd + "res = z + z.imag"
 
+    def test_conj(self, cmd):
+        return cmd + "res = z.conj()"
 
+    def test_conj_method(self, cmd):
+        return cmd + "res = M.conj(z)"
+
+    def test_conjugate(self, cmd):
+        return cmd + "res = z.conjugate()"
+
+    def test_conjugate_method(self, cmd):
+        return cmd + "res = M.conjugate(z)"


### PR DESCRIPTION
This solves the first half of #370. Namely, it lets you use `bh.conj` and `bh.conjugate` (alias)

```python
import bohrium as bh
a = bh.arange(5) + 1j # => array([ 0.+1.j,  1.+1.j,  2.+1.j,  3.+1.j,  4.+1.j])

bh.conj(a)            # => array([ 0.-1.j,  1.-1.j,  2.-1.j,  3.-1.j,  4.-1.j])
bh.conjugate(a)       # => array([ 0.-1.j,  1.-1.j,  2.-1.j,  3.-1.j,  4.-1.j])
a.conj()              # => array([ 0.-1.j,  1.-1.j,  2.-1.j,  3.-1.j,  4.-1.j])
a.conjugate()         # => array([ 0.-1.j,  1.-1.j,  2.-1.j,  3.-1.j,  4.-1.j])
```

---

The other half being, that @mfherbst wants this:

```python
import bohrium as bh
a = bh.arange(5) + 1j     # => array([ 0.+1.j,  1.+1.j,  2.+1.j,  3.+1.j,  4.+1.j])
a.real = bh.arange(5) + 2 # => array([ 2.+1.j,  3.+1.j,  4.+1.j,  5.+1.j,  6.+1.j])
```

This gives a warning about letting Numpy handle it.