### PR TITLE
Represent single values without array prefix

### DIFF
--- a/bridge/npbackend/src/_bh.c
+++ b/bridge/npbackend/src/_bh.c
@@ -1105,7 +1105,44 @@ static PyObject* BhArray_Repr(PyObject *self) {
         return NULL;
     }
 
-    PyObject *str = PyArray_Type.tp_repr(t);
+    PyObject *str = NULL;
+
+    BH_PyArrayObject *base = &((BhArray*) self)->base;
+    if (base->nd == 0) {
+        // 0-rank array -> single value
+        void *data = PyArray_GetPtr((PyArrayObject*) self, 0);
+        char c[32];
+
+        switch (base->descr->type) {
+            case 'i': // int32
+                snprintf(c, sizeof(c), "%d", *((npy_int*) data));
+                break;
+            case 'l': // int64
+                snprintf(c, sizeof(c), "%ld", *((npy_long*) data));
+                break;
+            case 'I': // uint32
+                 snprintf(c, sizeof(c), "%u", *((npy_uint*) data));
+                break;
+            case 'L': // uint64
+                 snprintf(c, sizeof(c), "%lu", *((npy_ulong*) data));
+                break;
+            case 'f': // float
+                snprintf(c, sizeof(c), "%.6g", *((npy_float*) data));
+                break;
+            case 'd': // double
+                snprintf(c, sizeof(c), "%.6g", *((npy_double*) data));
+                break;
+        }
+
+        if (c[0] == 0) {
+            str = PyArray_Type.tp_repr(t);
+        } else {
+            str = PyString_FromString(c);
+        }
+    } else {
+        str = PyArray_Type.tp_repr(t);
+    }
+
     Py_DECREF(t);
 
     return str;

--- a/bridge/npbackend/src/_bh.c
+++ b/bridge/npbackend/src/_bh.c
@@ -1137,7 +1137,11 @@ static PyObject* BhArray_Repr(PyObject *self) {
         if (c[0] == 0) {
             str = PyArray_Type.tp_repr(t);
         } else {
+#if defined(NPY_PY3K)
+            str = PyUnicode_FromString(c);
+#else
             str = PyString_FromString(c);
+#endif
         }
     } else {
         str = PyArray_Type.tp_repr(t);

--- a/test/python/tests/test_repr.py
+++ b/test/python/tests/test_repr.py
@@ -1,0 +1,31 @@
+import util
+
+class test_single_repr:
+    def init(self):
+        for t in util.TYPES.NORMAL:
+            cmd = "a = M.array([1.234]).astype(%s).sum();" % t
+            yield cmd
+
+    def test_repr(self, cmd):
+        cmd += "res = a.__repr__();"
+        return cmd
+
+    def test_str(self, cmd):
+        cmd += "res = a.__str__();"
+        cmd += "res = float(res)"
+        return cmd
+
+
+class test_array_repr:
+    def init(self):
+        for t in util.TYPES.NORMAL:
+            cmd = "a = M.arange(10).astype(%s);" % t
+            yield cmd
+
+    def test_repr(self, cmd):
+        cmd += "res = a.__repr__();"
+        return cmd
+
+    def test_str(self, cmd):
+        cmd += "res = a.__str__();"
+        return cmd


### PR DESCRIPTION
Fixes #405 by representing single values without the `array(...)` "prefix".