### PR TITLE
Trying to streamline Travis a bit

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,14 +1,7 @@
 services:
   - docker
 
-language: c
-
-compiler:
-  - gcc
-
-before_install:
-  - docker pull bohrium/ubuntu:16.04
-  - docker build -t bohrium_release -f package/docker/bohrium.dockerfile .
+language: python
 
 env:
   global:
@@ -16,26 +9,37 @@ env:
     - BH_OPENMP_VOLATILE=true
     - BH_OPENCL_PROF=true
     - BH_OPENCL_VOLATILE=true
+    - TEST_RUN="/bohrium/test/python/run.py /bohrium/test/python/tests/test_*.py"
+    - BENCHMARK_RUN="/bohrium/test/python/numpytest.py --file test_benchmarks.py"
 
-  matrix:
-    # All test_*.py scripts
-    - BH_STACK=openmp PY_EXEC=python2.7 TEST_EXEC="$PY_EXEC /bohrium/test/python/run.py /bohrium/test/python/tests/test_*.py"
-    - BH_STACK=openmp BH_OPENMP_MONOLITHIC=true PY_EXEC=python2.7 TEST_EXEC="$PY_EXEC /bohrium/test/python/run.py /bohrium/test/python/tests/test_*.py"
-    - BH_STACK=opencl PY_EXEC=python2.7 TEST_EXEC="$PY_EXEC /bohrium/test/python/run.py /bohrium/test/python/tests/test_*.py"
-    - BH_STACK=openmp PY_EXEC=python3.5 TEST_EXEC="$PY_EXEC /bohrium/test/python/run.py /bohrium/test/python/tests/test_*.py"
-    - BH_STACK=opencl PY_EXEC=python3.5 TEST_EXEC="$PY_EXEC /bohrium/test/python/run.py /bohrium/test/python/tests/test_*.py"
+script:
+  - env | grep -v "PATH" | grep -v "TRAVIS" | sort > .env-file
+  - cat .env-file
+  - docker pull bohrium/bohrium:latest
+  - docker run -t --env-file .env-file bohrium/bohrium
 
-    # Test of the proxy backend
-    - BH_STACK=proxy_opencl PY_EXEC=python2.7 TEST_EXEC="/usr/bin/bh_proxy_backend -a localhost -p 4200 & $PY_EXEC /bohrium/test/python/run.py /bohrium/test/python/tests/test_!(nobh).py"
+jobs:
+  include:
+    - stage: build docker image
+      script:
+        - docker login -u="$DOCKER_USER" -p="$DOCKER_PASSWORD"
+        - docker build -t bohrium/bohrium -f package/docker/bohrium.dockerfile .
+        - docker push bohrium/bohrium
 
-    # The test_benchmarks.py script
-    - BH_STACK=openmp PY_EXEC=python2.7 TEST_EXEC="$PY_EXEC /bohrium/test/python/numpytest.py --file test_benchmarks.py"
-    - BH_STACK=opencl PY_EXEC=python2.7 TEST_EXEC="$PY_EXEC /bohrium/test/python/numpytest.py --file test_benchmarks.py"
-    - BH_STACK=openmp PY_EXEC=python3.5 TEST_EXEC="$PY_EXEC /bohrium/test/python/numpytest.py --file test_benchmarks.py"
-    - BH_STACK=opencl PY_EXEC=python3.5 TEST_EXEC="$PY_EXEC /bohrium/test/python/numpytest.py --file test_benchmarks.py"
+    - stage: verify
+    # Test suite
+      env: PY_EXEC="python2.7" BH_STACK=openmp TEST_EXEC="$PY_EXEC $TEST_RUN"
+    - env: PY_EXEC="python2.7" BH_STACK=opencl TEST_EXEC="$PY_EXEC $TEST_RUN"
+    - env: PY_EXEC="python2.7" BH_STACK=openmp BH_OPENMP_MONOLITHIC=true TEST_EXEC="$PY_EXEC $TEST_RUN"
+    - env: PY_EXEC="python2.7" BH_STACK=proxy_opencl TEST_EXEC="/usr/bin/bh_proxy_backend -a localhost -p 4200 & $PY_EXEC /bohrium/test/python/run.py /bohrium/test/python/tests/test_!(nobh).py"
+    - env: PY_EXEC="python3.5" BH_STACK=openmp TEST_EXEC="$PY_EXEC $TEST_RUN"
+    - env: PY_EXEC="python3.5" BH_STACK=opencl TEST_EXEC="$PY_EXEC $TEST_RUN"
+
+    # Benchmarks
+    - env: PY_EXEC="python2.7" BH_STACK=openmp TEST_EXEC="$PY_EXEC $BENCHMARK_RUN"
+    - env: PY_EXEC="python2.7" BH_STACK=opencl TEST_EXEC="$PY_EXEC $BENCHMARK_RUN"
+    - env: PY_EXEC="python3.5" BH_STACK=openmp TEST_EXEC="$PY_EXEC $BENCHMARK_RUN"
+    - env: PY_EXEC="python3.5" BH_STACK=opencl TEST_EXEC="$PY_EXEC $BENCHMARK_RUN"
 
 notifications:
   slack: bohrium:BCAEW8qYK5fmkt8f5mW95GUe
-
-script:
-  - docker run -t -e BH_STACK -e BH_OPENMP_PROF -e BH_OPENCL_PROF -e BH_OPENMP_VOLATILE -e BH_OPENCL_VOLATILE -e BH_OPENMP_MONOLITHIC -e PY_EXEC -e TEST_EXEC bohrium_release

--- a/package/docker/base.dockerfile
+++ b/package/docker/base.dockerfile
@@ -26,7 +26,7 @@ RUN apt-get -qq install python-matplotlib python3-matplotlib > /dev/null
 RUN apt-get -qq install python-netcdf4 python3-netcdf4 > /dev/null
 RUN apt-get -qq install python-pyopencl python3-pyopencl > /dev/null
 RUN apt-get -qq install zlib1g-dev > /dev/null
-#RUN apt-get -qq install valgrind gdb vim cgdb > /dev/null
+# RUN apt-get -qq install valgrind gdb vim cgdb > /dev/null
 
 # Install OpenCV 3
 ADD https://github.com/opencv/opencv/archive/3.2.0.zip .
@@ -43,8 +43,6 @@ RUN mkdir -p /opt/amd_src
 ADD AMD-APP-SDK-linux-v2.9-1.599.381-GA-x64.tar.bz2 /opt/amd_src
 ENV OPENCL_HOME /opt/AMDAPPSDK-2.9-1
 ENV OPENCL_LIBPATH /opt/AMDAPPSDK-2.9-1/lib/x86_64
-
-# RUN tar xjf AMD-APP-SDK-linux-v2.9-1.599.381-GA-x64.tar.bz2
 RUN sh /opt/amd_src/AMD-APP-SDK-v2.9-1.599.381-GA-linux64.sh -- -s -a yes > /dev/null
 ENV OpenCL_LIBPATH "/opt/AMDAPPSDK-2.9-1/lib/x86_64/"
 ENV OpenCL_INCPATH "/opt/AMDAPPSDK-2.9-1/include"

--- a/package/docker/bohrium.dockerfile
+++ b/package/docker/bohrium.dockerfile
@@ -26,5 +26,11 @@ RUN make install
 
 # Test Suite
 WORKDIR /bohrium
-ENTRYPOINT export PYTHONPATH="/usr/lib/$PY_EXEC/site-packages:$PYTHONPATH" && export && echo "shopt -s extglob"> test_exec.sh && echo "$TEST_EXEC" >> test_exec.sh && echo "Test commands: " && cat test_exec.sh && bash test_exec.sh
 
+RUN echo "#/usr/bin/env bash" > test_exec.sh && \
+    echo "shopt -s extglob" >> test_exec.sh  && \
+    chmod +x test_exec.sh
+
+ENTRYPOINT export PYTHONPATH="/usr/lib/$PY_EXEC/site-packages:$PYTHONPATH" && \
+           echo "$TEST_EXEC" >> test_exec.sh                               ; \
+           bash test_exec.sh


### PR DESCRIPTION
Uses Travis' new `jobs` feature to build the docker image once and then pull it for each test suite.

This shaves off about 15 minutes of wall time, but about 1 hour of CPU time on Travis' VMs.