### PR TITLE
Fixed assigned value twice

### DIFF
--- a/extmethods/visualizer/visualizer.cpp
+++ b/extmethods/visualizer/visualizer.cpp
@@ -405,7 +405,7 @@ void Visualizer::computeVerticesCube()
         {
             for (int zi = 0; zi < depth; zi++ )
             {
-                uint64_t offset = (xi * width + yi) * depth + zi;
+                uint64_t offset;
                 offset = i;
                 float dx = (XWIDTH/2.0f)/ (float)(width);
                 float dy = (YWIDTH/2.0f)/ (float)(height);


### PR DESCRIPTION
I'm a member of the Pinguem.ru competition on finding errors in open source projects. A warning, found using PVS-Studio:
bohrium/extmethods/visualizer/visualizer.cpp        409     warn    V519 The 'offset' variable is assigned values twice successively. Perhaps this is a mistake. Check lines: 408, 409.

The first assigned value will lost.