### PR TITLE
New static analyser issue.

### DIFF
--- a/core/jitk/compiler.cpp
+++ b/core/jitk/compiler.cpp
@@ -52,7 +52,6 @@ void Compiler::compile(string object_abspath, const char* sourcecode, size_t sou
     if (!cmd_stdin) {
         perror("popen()");
         fprintf(stderr, "popen() failed for: [%s]", sourcecode);
-        pclose(cmd_stdin);
         throw runtime_error("Compiler: popen() failed");
     }
                                                 // Write / pipe to stdin


### PR DESCRIPTION
The Pinguem.ru competition on finding errors in open source projects. Warnings, found using PVS-Studio:
bohrium/core/jitk/compiler.cpp      55      err     V575 The null pointer is passed into 'pclose' function. Inspect the first argument.

If pipe wasn't open it shouldn't be closed.