### PR TITLE
Warn user about inter-bridge dependencies

### DIFF
--- a/bridge/c/CMakeLists.txt
+++ b/bridge/c/CMakeLists.txt
@@ -1,7 +1,10 @@
 cmake_minimum_required(VERSION 2.8)
-set(BRIDGE_C true CACHE BOOL "BRIDGE-C: Build the C-bridge.")
+set(BRIDGE_C ${BRIDGE_BHXX} CACHE BOOL "BRIDGE-C: Build the C-bridge.")
 if(NOT BRIDGE_C)
     return()
+endif()
+if(NOT BRIDGE_BHXX)
+    message(FATAL_ERROR "BRIDGE_BHXX is required for BRIDGE_C, so please set BRIDGE_BHXX to ON or BRIDGE_C to OFF")
 endif()
 
 include_directories(${CMAKE_SOURCE_DIR}/include)

--- a/bridge/npbackend/CMakeLists.txt
+++ b/bridge/npbackend/CMakeLists.txt
@@ -1,7 +1,10 @@
 cmake_minimum_required(VERSION 2.8)
-set(BRIDGE_NPBACKEND true CACHE BOOL "BRIDGE-NPBACKEND: Build the NPBACKEND-bridge.")
+set(BRIDGE_NPBACKEND ${BRIDGE_C} CACHE BOOL "BRIDGE-NPBACKEND: Build the NPBACKEND-bridge.")
 if(NOT BRIDGE_NPBACKEND)
     return()
+endif()
+if(NOT BRIDGE_C)
+    message(FATAL_ERROR "BRIDGE_C is required for BRIDGE_NPBACKEND, so please set BRIDGE_C to ON or BRIDGE_NPBACKEND to OFF")
 endif()
 
 find_package(NumPy)


### PR DESCRIPTION
Currently bohrium cannot be build with the npbackend if the c bridge is not enabled and the c bridge in turn cannot be build if the bhxx bridge is not enabled. This PR catches this during the configuration stage of the build and tells the user about it.