### PR TITLE
cmake: removed the OpenMP hack for OSX

### DIFF
--- a/ve/openmp/CMakeLists.txt
+++ b/ve/openmp/CMakeLists.txt
@@ -27,25 +27,7 @@ include(FeatureSummary)
 find_package(OpenMP)
 set_package_properties(OpenMP PROPERTIES TYPE RECOMMENDED PURPOSE "Multicore processing, essential for performance of the CPU VE.")
 
-# If not found on Apple with Clang, we try again with no warnings
-# NOTE: This was fixed in CMake 3.9.4
-if(NOT(OPENMP_FOUND OR OpenMP_C_FOUND) AND APPLE)
-    unset(OpenMP_C_FLAGS CACHE)
-    unset(OpenMP_C_LIB_NAMES CACHE)
-    unset(OpenMP_CXX_FLAGS CACHE)
-    unset(OpenMP_CXX_LIB_NAMES CACHE)
-
-    # Clang will break find_package(OpenMP) because CMake supplies '-Werror' and a linker command line argument, which isn't used.
-    # Therefore we add '-Wno-unused-command-line-argument'
-    if(CMAKE_C_COMPILER_ID STREQUAL "Clang")
-        set(OpenMP_C_FLAG "-fopenmp=libomp -Wno-unused-command-line-argument")
-    endif()
-    if(CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
-        set(OpenMP_CXX_FLAG "-fopenmp=libomp -Wno-unused-command-line-argument")
-    endif()
-    find_package(OpenMP)
-endif()
-
+# Check OpenMP SIMD support
 if(OPENMP_FOUND OR OpenMP_C_FOUND)
     # Check for the SIMD flag
     set(OpenMP_SIMD_C_FLAGS "${OpenMP_C_FLAGS} ${OpenMP_C_FLAGS}-simd")


### PR DESCRIPTION
It makes builds that support SIMD fail.
The problem is fixed in CMake v3.9.4