### PR TITLE
CamelCase methods in classes

### DIFF
--- a/bridge/c/gen_specials.py
+++ b/bridge/c/gen_specials.py
@@ -52,7 +52,7 @@ def main(args):
     impl += """
 {
     std::shared_ptr<bhxx::BhBase> dummy;
-    bhxx::Runtime::instance().flush_and_repeat(nrepeats, dummy);
+    bhxx::Runtime::instance().flushAndRepeat(nrepeats, dummy);
 }
 """
 
@@ -64,7 +64,7 @@ def main(args):
     impl += """
 {
     std::shared_ptr<bhxx::BhBase> &b = ((bhxx::BhArray<bool>*)condition)->base;
-    bhxx::Runtime::instance().flush_and_repeat(nrepeats, b);
+    bhxx::Runtime::instance().flushAndRepeat(nrepeats, b);
 }
 """
 
@@ -85,12 +85,12 @@ def main(args):
     doc = "\n// Get the device context, such as OpenCL's cl_context, of the first VE in the runtime stack.\n"
     doc += "// If the first VE isn't a device, NULL is returned.\n"
     impl += doc; head += doc
-    decl = "void* bhc_get_device_context(void)"
+    decl = "void* bhc_getDeviceContext(void)"
     head += "DLLEXPORT %s;\n" % decl
     impl += "%s" % decl
     impl += """
 {
-    return bhxx::Runtime::instance().get_device_context();
+    return bhxx::Runtime::instance().getDeviceContext();
 }
 """
 
@@ -102,7 +102,7 @@ def main(args):
     impl += "%s" % decl
     impl += """
 {
-    bhxx::Runtime::instance().set_device_context((void*)device_context);
+    bhxx::Runtime::instance().setDeviceContext((void*)device_context);
 }
 """
 
@@ -168,7 +168,7 @@ def main(args):
         impl += """\
 {
     std::shared_ptr<bhxx::BhBase> &b = ((bhxx::BhArray<%(cpp)s>*)ary)->base;
-    return bhxx::Runtime::instance().get_mem_ptr(b, copy2host, force_alloc, nullify);
+    return bhxx::Runtime::instance().getMemoryPointer(b, copy2host, force_alloc, nullify);
 }
 
 """ % t
@@ -184,7 +184,7 @@ def main(args):
         impl += """\
 {
    std::shared_ptr<bhxx::BhBase> &b = ((bhxx::BhArray<%(cpp)s>*)ary)->base;
-   bhxx::Runtime::instance().set_mem_ptr(b, host_ptr, data);
+   bhxx::Runtime::instance().setMemoryPointer(b, host_ptr, data);
 }
 
 """ % t
@@ -214,7 +214,7 @@ def main(args):
         impl += """
 {
     try {
-        bhxx::Runtime::instance().enqueue_extmethod(
+        bhxx::Runtime::instance().enqueueExtmethod(
             name,
             *((bhxx::BhArray<%(cpp)s>*) out),
             *((bhxx::BhArray<%(cpp)s>*) in1),

--- a/bridge/cxx/gen_array_operations.py
+++ b/bridge/cxx/gen_array_operations.py
@@ -74,7 +74,7 @@ def main(args):
     impl += "%s\n" % decl
     impl += """
 {
-    \tRuntime::instance().enqueue_random(out, seed, key);
+    \tRuntime::instance().enqueueRandom(out, seed, key);
 }
 """
 

--- a/bridge/cxx/include/bhxx/BhArray.hpp
+++ b/bridge/cxx/include/bhxx/BhArray.hpp
@@ -70,7 +70,8 @@ class BhArray {
     }
 
     /** Create a new view (contiguous stride, row-major) */
-    BhArray(Shape shape) : BhArray(shape, contiguous_stride(shape), 0) {}
+    BhArray(Shape shape) :
+        BhArray(shape, contiguous_stride(shape), 0) {}
 
     /** Create a view that points to the given base
      *
@@ -80,8 +81,7 @@ class BhArray {
      *        construct a BhBase object, use the make_base_ptr
      *        helper function.
      */
-    BhArray(std::shared_ptr<BhBase> base_, Shape shape_, Stride stride_,
-            const size_t offset_ = 0)
+    BhArray(std::shared_ptr<BhBase> base_, Shape shape_, Stride stride_, const size_t offset_ = 0)
           : offset(offset_),
             shape(std::move(shape_)),
             stride(std::move(stride_)),
@@ -114,19 +114,20 @@ class BhArray {
     }
 
     /** Return the number of elements */
-    size_t n_elem() const { return shape.prod(); }
+    size_t numberOfElements() const {
+        return shape.prod();
+    }
 
     /** Return whether the view is contiguous and row-major */
-    bool is_contiguous() const;
+    bool isContiguous() const;
 
     //
     // Data access
     //
     /** Is the data referenced by this view's base array already
      *  allocated, i.e. initialised */
-    bool is_data_initialised() const { return base->data != nullptr; }
+    bool isDataInitialised() const { return base->data != nullptr; }
 
-    //@{
     /** Obtain the data pointer of the base array, not taking
      *  ownership of any kind.
      *
@@ -137,8 +138,7 @@ class BhArray {
      *        out of sync with Bohrium.
      */
     const T* data() const { return static_cast<T*>(base->data); }
-    T*       data() { return static_cast<T*>(base->data); }
-    //@}
+          T* data()       { return static_cast<T*>(base->data); }
 
     //
     // Routines

--- a/bridge/cxx/include/bhxx/BhBase.hpp
+++ b/bridge/cxx/include/bhxx/BhBase.hpp
@@ -25,14 +25,16 @@ If not, see <http://www.gnu.org/licenses/>.
 namespace bhxx {
 // The base underlying (multiple) arrays
 class BhBase : public bh_base {
-  public:
+public:
     /** Is the memory managed referenced by bh_base's data pointer
      *  managed by Bohrium or is it owned externally
      *
      * \note If this flag is false, the class will make sure that
      *       the memory is not deleted when going out of scope.
      *  */
-    bool own_memory() { return m_own_memory; }
+    bool ownMemory() {
+        return m_own_memory;
+    }
 
     /** Construct a base array with nelem elements using
      * externally managed storage.
@@ -44,7 +46,8 @@ class BhBase : public bh_base {
      * incorporate nelem_ elements.
      * */
     template <typename T>
-    BhBase(size_t nelem_, T* memory) : m_own_memory(false) {
+    BhBase(size_t nelem_, T* memory) :
+        m_own_memory(false) {
         data  = memory;
         nelem = static_cast<int64_t>(nelem_);
         set_type<T>();
@@ -57,8 +60,7 @@ class BhBase : public bh_base {
      *  provide external storage to Bohrium use the constructor
      *  BhBase(size_t nelem, T* memory) instead.
      */
-    template <typename InputIterator,
-              typename T = typename std::iterator_traits<InputIterator>::value_type>
+    template <typename InputIterator, typename T = typename std::iterator_traits<InputIterator>::value_type>
     BhBase(InputIterator begin, InputIterator end)
           : BhBase(T(0), static_cast<size_t>(std::distance(begin, end))) {
         assert(std::distance(begin, end) > 0);
@@ -81,7 +83,8 @@ class BhBase : public bh_base {
      *       do this via the BhArray interface and not using this constructor.
      */
     template <typename T>
-    BhBase(T dummy, size_t nelem_) : m_own_memory(true) {
+    BhBase(T dummy, size_t nelem_) :
+        m_own_memory(true) {
         data  = nullptr;
         nelem = nelem_;
         set_type<T>();
@@ -112,12 +115,14 @@ class BhBase : public bh_base {
     // would theoretically need to free it here.
 
     /** Move another BhBase object here */
-    BhBase(BhBase&& other) : bh_base(std::move(other)), m_own_memory(other.m_own_memory) {
+    BhBase(BhBase&& other) :
+        bh_base(std::move(other)),
+        m_own_memory(other.m_own_memory) {
         other.m_own_memory = true;
         other.data         = nullptr;
     }
 
-  private:
+private:
     /** Set the data type of the data pointed by data. */
     template <typename T>
     void set_type();

--- a/bridge/cxx/include/bhxx/BhInstruction.hpp
+++ b/bridge/cxx/include/bhxx/BhInstruction.hpp
@@ -27,33 +27,36 @@ namespace bhxx {
 /** Helper class to build instructions */
 class BhInstruction : public bh_instruction {
   public:
-    BhInstruction(bh_opcode code) : bh_instruction{} { opcode = code; }
+    BhInstruction(bh_opcode code) :
+        bh_instruction() {
+        opcode = code;
+    }
 
     /** Append a single array to the list of operands */
     template <typename T>
-    void append_operand(BhArray<T>& ary);
+    void appendOperand(BhArray<T>& ary);
 
     /** Append a const array to the list of operands */
     template <typename T>
-    void append_operand(const BhArray<T>& ary);
+    void appendOperand(const BhArray<T>& ary);
 
     /** Append a single scalar to the list of operands */
     template <typename T>
-    void append_operand(T scalar);
+    void appendOperand(T scalar);
 
     /** Append a list of operands  */
     template <typename T, typename... Ts>
-    void append_operand(T& op, Ts&... ops) {
-        append_operand(op);
-        append_operand(ops...);
+    void appendOperand(T& op, Ts&... ops) {
+        appendOperand(op);
+        appendOperand(ops...);
     }
 
     /** Append a special bh_constant */
-    void append_operand(bh_constant cnt);
+    void appendOperand(bh_constant cnt);
 
     /** Append a base object for deletion
      *
      * \note Only valid for BH_FREE */
-    void append_operand(BhBase& base);
+    void appendOperand(BhBase& base);
 };
 }

--- a/bridge/cxx/include/bhxx/util.hpp
+++ b/bridge/cxx/include/bhxx/util.hpp
@@ -33,7 +33,7 @@ T as_scalar(BhArray<T> ary);
  *  contiguous. */
 template <typename T>
 BhArray<T> as_contiguous(BhArray<T> ary) {
-    if (ary.is_contiguous()) return ary;
+    if (ary.isContiguous()) return ary;
 
     BhArray<T> contiguous{ary.shape};
     identity(contiguous, ary);
@@ -91,7 +91,7 @@ BhArray<T> accumulate(BhArray<T> op, AddReduction&& reduction) {
         op = reduction(op, op.rank() - 1);
     }
     assert(op.rank() == 1);
-    assert(op.n_elem() == 1);
+    assert(op.numberOfElements() == 1);
     return op;
 }
 

--- a/bridge/cxx/src/BhArray.cpp
+++ b/bridge/cxx/src/BhArray.cpp
@@ -34,7 +34,7 @@ void RuntimeDeleter::operator()(BhBase* ptr) const {
     // Simply hand the deletion over to Bohrium
     // including the ownership of the pointer to be deleted
     // by the means of a unique pointer.
-    Runtime::instance().enqueue_deletion(std::unique_ptr<BhBase>(ptr));
+    Runtime::instance().enqueueDeletion(std::unique_ptr<BhBase>(ptr));
 }
 
 //
@@ -42,7 +42,7 @@ void RuntimeDeleter::operator()(BhBase* ptr) const {
 //
 
 template <typename T>
-bool BhArray<T>::is_contiguous() const {
+bool BhArray<T>::isContiguous() const {
     assert(shape.size() == stride.size());
 
     auto itshape  = shape.rbegin();
@@ -54,7 +54,7 @@ bool BhArray<T>::is_contiguous() const {
         acc *= static_cast<int64_t>(*itshape);
     }
 
-    assert(acc == static_cast<int64_t>(n_elem()));
+    assert(acc == static_cast<int64_t>(numberOfElements()));
     return offset == 0;
 }
 

--- a/bridge/cxx/src/BhInstruction.cpp
+++ b/bridge/cxx/src/BhInstruction.cpp
@@ -22,14 +22,14 @@ If not, see <http://www.gnu.org/licenses/>.
 
 namespace bhxx {
 
-void BhInstruction::append_operand(bh_constant cnt) {
+void BhInstruction::appendOperand(bh_constant cnt) {
     bh_view view;
     view.base = nullptr;
     operand.push_back(view);
     constant = cnt;
 }
 
-void BhInstruction::append_operand(BhBase& base) {
+void BhInstruction::appendOperand(BhBase& base) {
     if (opcode != BH_FREE) {
         throw std::runtime_error(
               "BhBase objects can only be freed. Use a full BhArray if you want to "
@@ -48,7 +48,7 @@ void BhInstruction::append_operand(BhBase& base) {
 }
 
 template <typename T>
-void BhInstruction::append_operand(BhArray<T>& ary) {
+void BhInstruction::appendOperand(BhArray<T>& ary) {
     if (opcode == BH_FREE) {
         throw std::runtime_error(
               "BH_FREE cannot be used as an instruction on arrays in the bhxx interface. "
@@ -56,11 +56,11 @@ void BhInstruction::append_operand(BhArray<T>& ary) {
     }
 
     // Forward to the const version below.
-    append_operand(const_cast<const BhArray<T>&>(ary));
+    appendOperand(const_cast<const BhArray<T>&>(ary));
 }
 
 template <typename T>
-void BhInstruction::append_operand(const BhArray<T>& ary) {
+void BhInstruction::appendOperand(const BhArray<T>& ary) {
     if (opcode == BH_FREE) {
         throw std::runtime_error(
               "BH_FREE cannot be used as an instruction on arrays in the bhxx interface. "
@@ -77,7 +77,7 @@ void BhInstruction::append_operand(const BhArray<T>& ary) {
 }
 
 template <typename T>
-void BhInstruction::append_operand(T scalar) {
+void BhInstruction::appendOperand(T scalar) {
     bh_view view;
     view.base = nullptr;
     operand.push_back(view);
@@ -86,9 +86,9 @@ void BhInstruction::append_operand(T scalar) {
 
 // Instantiate all possible types for bh_instruction
 #define INSTANTIATE(TYPE)                                              \
-    template void BhInstruction::append_operand(TYPE);                 \
-    template void BhInstruction::append_operand(const BhArray<TYPE>&); \
-    template void BhInstruction::append_operand(BhArray<TYPE>&)
+    template void BhInstruction::appendOperand(TYPE);                 \
+    template void BhInstruction::appendOperand(const BhArray<TYPE>&); \
+    template void BhInstruction::appendOperand(BhArray<TYPE>&)
 
 INSTANTIATE(bool);
 INSTANTIATE(int8_t);

--- a/bridge/cxx/src/Runtime.cpp
+++ b/bridge/cxx/src/Runtime.cpp
@@ -41,30 +41,30 @@ void Runtime::enqueue(BhInstruction instr) {
     }
 }
 
-void Runtime::enqueue_random(BhArray<uint64_t>& out, uint64_t seed, uint64_t key) {
+void Runtime::enqueueRandom(BhArray<uint64_t>& out, uint64_t seed, uint64_t key) {
     BhInstruction instr(BH_RANDOM);
-    instr.append_operand(out);  // Append output array
+    instr.appendOperand(out);  // Append output array
 
     // Append the special BH_R123 constant
     bh_constant cnt;
     cnt.type             = bh_type::R123;
     cnt.value.r123.start = seed;
     cnt.value.r123.key   = key;
-    instr.append_operand(cnt);
+    instr.appendOperand(cnt);
 
     enqueue(std::move(instr));
 }
 
-void Runtime::enqueue_deletion(std::unique_ptr<BhBase> base_ptr) {
+void Runtime::enqueueDeletion(std::unique_ptr<BhBase> base_ptr) {
     // Check whether we are responsible for the memory or not.
-    if (!base_ptr->own_memory()) {
+    if (!base_ptr->ownMemory()) {
         // Externally managed
         // => set it to null to avoid deletion by Bohrium
         base_ptr->data = nullptr;
     }
 
     BhInstruction instr(BH_FREE);
-    instr.append_operand(*base_ptr);
+    instr.appendOperand(*base_ptr);
     bases_for_deletion.push_back(std::move(base_ptr));
     enqueue(std::move(instr));
 }
@@ -100,7 +100,7 @@ void Runtime::flush() {
     _flush(1, dummy, instr_list, syncs, runtime, bases_for_deletion, _flush_count);
 }
 
-void Runtime::flush_and_repeat(uint64_t nrepeats, const std::shared_ptr<BhBase> &base_ptr) {
+void Runtime::flushAndRepeat(uint64_t nrepeats, const std::shared_ptr<BhBase> &base_ptr) {
     _flush(nrepeats, base_ptr, instr_list, syncs, runtime, bases_for_deletion, _flush_count);
 }
 
@@ -112,20 +112,20 @@ std::string Runtime::message(const std::string &msg) {
     return runtime.message(msg);
 }
 
-void* Runtime::get_mem_ptr(std::shared_ptr<BhBase> &base, bool copy2host, bool force_alloc, bool nullify) {
-    return runtime.get_mem_ptr(*base, copy2host, force_alloc, nullify);
+void* Runtime::getMemoryPointer(std::shared_ptr<BhBase> &base, bool copy2host, bool force_alloc, bool nullify) {
+    return runtime.getMemoryPointer(*base, copy2host, force_alloc, nullify);
 }
 
-void Runtime::set_mem_ptr(std::shared_ptr<BhBase> &base, bool host_ptr, void *mem) {
-    return runtime.set_mem_ptr(base.get(), host_ptr, mem);
+void Runtime::setMemoryPointer(std::shared_ptr<BhBase> &base, bool host_ptr, void *mem) {
+    return runtime.setMemoryPointer(base.get(), host_ptr, mem);
 }
 
-void* Runtime::get_device_context() {
-    return runtime.get_device_context();
+void* Runtime::getDeviceContext() {
+    return runtime.getDeviceContext();
 }
 
-void Runtime::set_device_context(void *device_context) {
-    runtime.set_device_context(device_context);
+void Runtime::setDeviceContext(void *device_context) {
+    runtime.setDeviceContext(device_context);
 }
 
 }  // namespace bhxx

--- a/bridge/cxx/src/util.cpp
+++ b/bridge/cxx/src/util.cpp
@@ -32,7 +32,7 @@ T as_scalar(BhArray<T> ary) {
               "Cannot call bhxx::as_scalar on BhArray objects without base");
     }
 
-    if (ary.n_elem() != 1) {
+    if (ary.numberOfElements() != 1) {
         throw std::runtime_error(
               "Cannot call bhxx::as_scalar on BhArray objects with more than one "
               "element");
@@ -74,14 +74,14 @@ BhArray<T> transpose(BhArray<T> ary) {
 
 template <typename T>
 BhArray<T> reshape(BhArray<T> ary, Shape shape) {
-    if (ary.n_elem() != shape.prod()) {
+    if (ary.numberOfElements() != shape.prod()) {
         throw std::runtime_error(
               "Changing the shape cannot change the number of elements");
     }
 
     if (ary.shape == shape) return ary;
 
-    if (!ary.is_contiguous()) {
+    if (!ary.isContiguous()) {
         throw std::runtime_error(
               "Reshape not yet implemented for non-contiguous arrays.");
     }
@@ -118,18 +118,18 @@ BhArray<T> matmul(BhArray<T> lhs, BhArray<T> rhs) {
     Shape result_shape{lhs.shape.front(), rhs.shape.back()};
     if (lhs.rank() == 1) {
         result_shape = {rhs.shape.back()};
-        lhs          = reshape(std::move(lhs), {1, lhs.n_elem()});
+        lhs          = reshape(std::move(lhs), {1, lhs.numberOfElements()});
     }
     if (rhs.rank() == 1) {
         result_shape = {lhs.shape.front()};
-        rhs          = reshape(std::move(rhs), {rhs.n_elem(), 1});
+        rhs          = reshape(std::move(rhs), {rhs.numberOfElements(), 1});
     }
 
     BhArray<T> result({lhs.shape.front(), rhs.shape.back()});
     try {
         lhs = as_contiguous(std::move(lhs));
         rhs = as_contiguous(std::move(rhs));
-        Runtime::instance().enqueue_extmethod("blas_gemm", result, lhs, rhs);
+        Runtime::instance().enqueueExtmethod("blas_gemm", result, lhs, rhs);
     } catch (...) {
         // No blas could be found.
         // TODO Use check function once it is available

--- a/bridge/npbackend/bohrium/interop_pyopencl.py
+++ b/bridge/npbackend/bohrium/interop_pyopencl.py
@@ -3,7 +3,7 @@ Interop PyOpenCL
 ~~~~~~~~~~~~~~~~
 """
 from .bhary import get_bhc, get_base
-from .target import get_data_pointer, get_device_context, set_data_pointer
+from .target import get_data_pointer, getDeviceContext, set_data_pointer
 from .backend_messaging import runtime_info
 
 _opencl_is_in_stack = None
@@ -43,7 +43,7 @@ def available():
 def get_context():
     """Return a PyOpenCL context"""
     pyopencl = _import_pyopencl_module()
-    cxt = get_device_context()
+    cxt = getDeviceContext()
     if cxt is None:
         raise RuntimeError("No OpenCL device in the Bohrium stack! "
                            "Try defining the environment variable `BH_STACK=opencl`.")

--- a/bridge/npbackend/bohrium/target/interface.py
+++ b/bridge/npbackend/bohrium/target/interface.py
@@ -112,12 +112,12 @@ def set_data_pointer(ary, mem_ptr_as_int, host_ptr=True):
     raise NotImplementedError()
 
 
-def get_device_context():
+def getDeviceContext():
     """Get the device context, such as OpenCL's cl_context, of the first VE in the runtime stack."""
     raise NotImplementedError()
 
 
-def set_device_context(device_context):
+def setDeviceContext(device_context):
     """Set the device context, such as CUDA's cl_context, of the first VE in the runtime stack."""
     raise NotImplementedError()
 

--- a/bridge/npbackend/bohrium/target/target_bhc.py
+++ b/bridge/npbackend/bohrium/target/target_bhc.py
@@ -168,14 +168,14 @@ def set_data_pointer(ary, mem_ptr_as_int, host_ptr=True):
     bhc.call_single_dtype("data_set", dtype, ary, host_ptr, mem_ptr_as_int)
 
 
-def get_device_context():
+def getDeviceContext():
     """Get the device context, such as OpenCL's cl_context, of the first VE in the runtime stack."""
-    return int(bhc.get_device_context())
+    return int(bhc.getDeviceContext())
 
 
-def set_device_context(device_context):
+def setDeviceContext(device_context):
     """Set the device context, such as CUDA's cl_context, of the first VE in the runtime stack."""
-    bhc.set_device_context(device_context)
+    bhc.setDeviceContext(device_context)
 
 
 def set_bhc_data_from_ary(self, ary):

--- a/core/bh_instruction.cpp
+++ b/core/bh_instruction.cpp
@@ -57,7 +57,7 @@ vector<const bh_view*> bh_instruction::get_views() const {
     return ret;
 }
 
-bool bh_instruction::is_contiguous() const {
+bool bh_instruction::isContiguous() const {
     for(const bh_view &view: operand) {
         if ((not bh_is_constant(&view)) and (not bh_is_contiguous(&view)))
             return false;
@@ -83,7 +83,7 @@ bool bh_instruction::all_same_shape() const {
 bool bh_instruction::reshapable() const {
     // It is not meaningful to reshape instructions with different shaped views
     // and for now we cannot reshape non-contiguous or sweeping instructions
-    return all_same_shape() and is_contiguous() and not bh_opcode_is_sweep(opcode);
+    return all_same_shape() and isContiguous() and not bh_opcode_is_sweep(opcode);
 }
 
 vector<int64_t> bh_instruction::shape() const {

--- a/core/bh_ir.cpp
+++ b/core/bh_ir.cpp
@@ -114,7 +114,7 @@ BhIR::BhIR(const std::vector<char> &serialized_archive, std::map<const bh_base*,
 
 }
 
-std::vector<char> BhIR::write_serialized_archive(set<bh_base *> &known_base_arrays, vector<bh_base *> &new_data) {
+std::vector<char> BhIR::writeSerializedArchive(set<bh_base *> &known_base_arrays, vector<bh_base *> &new_data) {
 
     // Find new base arrays in 'bhir', which the de-serializing component should know about, and their data (if any)
     vector<bh_base> new_bases; // New base arrays in the order they appear in the instruction list

--- a/core/jitk/block.cpp
+++ b/core/jitk/block.cpp
@@ -76,7 +76,7 @@ void add_instr_to_block(LoopB &block, InstrPtr instr, int rank, int64_t size_of_
         assert(max_ndim == rank + 1);
         block._block_list.emplace_back(*instr, rank + 1);
     }
-    block.metadata_update();
+    block.metadataUpdate();
 }
 
 } // Anonymous name space
@@ -117,7 +117,7 @@ bool LoopB::isSystemOnly() const {
     return true;
 }
 
-void LoopB::getAllSubBlocks(std::vector<const LoopB *> &out) const {
+void LoopB::getAllSubBlocks(std::vector<const LoopB*> &out) const {
     for (const Block &b : _block_list) {
         if (not b.isInstr()) {
             out.push_back(&b.getLoop());
@@ -126,8 +126,8 @@ void LoopB::getAllSubBlocks(std::vector<const LoopB *> &out) const {
     }
 }
 
-vector<const LoopB *> LoopB::getLocalSubBlocks() const {
-    vector<const LoopB *> ret;
+vector<const LoopB*> LoopB::getLocalSubBlocks() const {
+    vector<const LoopB*> ret;
     for (const Block &b : _block_list) {
         if (not b.isInstr()) {
             ret.push_back(&b.getLoop());
@@ -304,7 +304,7 @@ bool LoopB::validation() const {
     return true;
 }
 
-void LoopB::insert_system_after(InstrPtr instr, const bh_base *base) {
+void LoopB::insertSystemAfter(InstrPtr instr, const bh_base *base) {
     assert(validation());
 
     LoopB *block;
@@ -380,7 +380,7 @@ string LoopB::pprint(const char *newline) const {
     return ss.str();
 }
 
-void LoopB::metadata_update() {
+void LoopB::metadataUpdate() {
     _news.clear();
     _frees.clear();
     _sweeps.clear();
@@ -493,7 +493,7 @@ Block create_nested_block(const vector<InstrPtr> &instr_list, int rank) {
     } else {
         ret_loop._block_list.emplace_back(create_nested_block(instr_list, rank+1));
     }
-    ret_loop.metadata_update();
+    ret_loop.metadataUpdate();
     assert(ret_loop.validation());
     return Block(std::move(ret_loop));
 }
@@ -514,11 +514,11 @@ Block create_nested_block(const vector<InstrPtr> &instr_list, int rank, int64_t 
     return Block(std::move(ret));
 }
 
-pair<vector<const LoopB *>, uint64_t> util_find_threaded_blocks(const LoopB &block) {
+pair<vector<const LoopB*>, uint64_t> util_find_threaded_blocks(const LoopB &block) {
     pair<vector<const LoopB*>, uint64_t> ret;
 
     // We should search in 'this' block and its sub-blocks
-    vector<const LoopB *> block_list = {&block};
+    vector<const LoopB*> block_list = {&block};
     block.getAllSubBlocks(block_list);
 
     // Find threaded blocks

--- a/core/jitk/fuser.cpp
+++ b/core/jitk/fuser.cpp
@@ -229,7 +229,7 @@ vector<Block> pre_fuser_lossy(const vector<bh_instruction *> &instr_list) {
         block_lists.push_back({*it});
         vector<InstrPtr> &block = block_lists.back();
         if (bh_opcode_is_system((*it)->opcode)) {
-            // We should not make blocks that start with a sysop since we only have LoopB::insert_system_after()
+            // We should not make blocks that start with a sysop since we only have LoopB::insertSystemAfter()
             continue;
         }
         ++it;

--- a/core/jitk/fuser_cache.cpp
+++ b/core/jitk/fuser_cache.cpp
@@ -104,11 +104,11 @@ size_t hash_instr_list(const vector<bh_instruction *> &instr_list) {
     return hasher(ss.str());
 }
 
-void updateWithOrigin(bh_view &view, const bh_view &origin) {
+void update_with_origin(bh_view &view, const bh_view &origin) {
     view.base = origin.base;
 }
 
-void updateWithOrigin(bh_instruction &instr, const bh_instruction *origin) {
+void update_with_origin(bh_instruction &instr, const bh_instruction *origin) {
     assert(instr.origin_id == origin->origin_id);
     assert(instr.opcode == origin->opcode);
 
@@ -117,23 +117,23 @@ void updateWithOrigin(bh_instruction &instr, const bh_instruction *origin) {
             // NB: sweeped axis values shouldn't be updated
             instr.constant = origin->constant;
         } else {
-            updateWithOrigin(instr.operand[i], origin->operand[i]);
+            update_with_origin(instr.operand[i], origin->operand[i]);
         }
     }
 }
 
-void updateWithOrigin(Block &block, const map<int64_t, const bh_instruction *> &origin_id_to_instr) {
+void update_with_origin(Block &block, const map<int64_t, const bh_instruction *> &origin_id_to_instr) {
     if (block.isInstr()) {
         assert(block.getInstr()->origin_id >= 0);
         bh_instruction instr(*block.getInstr());
-        updateWithOrigin(instr, origin_id_to_instr.at(instr.origin_id));
+        update_with_origin(instr, origin_id_to_instr.at(instr.origin_id));
         block.setInstr(instr);
     } else {
         LoopB &loop = block.getLoop();
         for (Block &b: loop._block_list) {
-            updateWithOrigin(b, origin_id_to_instr);
+            update_with_origin(b, origin_id_to_instr);
         }
-        loop.metadata_update();
+        loop.metadataUpdate();
     }
 }
 
@@ -153,7 +153,7 @@ pair<vector<Block>, bool> FuseCache::get(const vector<bh_instruction *> &instr_l
         }
         // Let's update the cached blocks in 'ret' with the base data from origin
         for(Block &block: ret) {
-            updateWithOrigin(block, origin_id_to_instr);
+            update_with_origin(block, origin_id_to_instr);
         }
         return make_pair(ret, true);
     } else { // Cache miss!

--- a/core/jitk/graph.cpp
+++ b/core/jitk/graph.cpp
@@ -101,7 +101,7 @@ DAG from_block_list(const vector<Block> &block_list) {
 
         // Finally, let's add edges to 'vertex'
         BOOST_REVERSE_FOREACH (Vertex v, connecting_vertices) {
-            if (vertex != v and block.depend_on(graph[v])) {
+            if (vertex != v and block.dependOn(graph[v])) {
                 boost::add_edge(v, vertex, graph);
             }
         }

--- a/core/jitk/transformer.cpp
+++ b/core/jitk/transformer.cpp
@@ -53,7 +53,7 @@ vector<Block> swap_blocks(const LoopB &parent, const LoopB *child) {
             const vector<InstrPtr> t = swap_axis(child->getAllInstr(), parent.rank, child->rank);
             loop._block_list.push_back(create_nested_block(t, child->rank, parent.size));
         }
-        loop.metadata_update();
+        loop.metadataUpdate();
         ret.push_back(Block(std::move(loop)));
     }
     return ret;
@@ -114,7 +114,7 @@ bool collapse_instr_axes(LoopB &loop, const int axis) {
             }
         }
     }
-    loop.metadata_update();
+    loop.metadataUpdate();
     assert(loop.validation());
     return true;
 }
@@ -192,7 +192,7 @@ void split_for_threading(vector<Block> &block_list, uint64_t min_threading, uint
                         ++it;
                     }
                     if (not newloop._block_list.empty()) {
-                        newloop.metadata_update();
+                        newloop.metadataUpdate();
                         ret.push_back(Block(std::move(newloop)));
                     }
                 }
@@ -204,7 +204,7 @@ void split_for_threading(vector<Block> &block_list, uint64_t min_threading, uint
                     newloop.rank = loop.rank;
                     newloop.size = loop.size;
                     newloop._block_list.push_back(*it);
-                    newloop.metadata_update();
+                    newloop.metadataUpdate();
                     ret.push_back(Block(std::move(newloop)));
                 } else {
                     break;

--- a/extmethods/blas/templates/body.tpl
+++ b/extmethods/blas/templates/body.tpl
@@ -2,7 +2,7 @@ struct @!uname!@Impl : public ExtmethodImpl {
 public:
     void execute(bh_instruction *instr, void* arg) {
         // All matrices must be contigous
-        assert(instr->is_contiguous());
+        assert(instr->isContiguous());
 
         // A is a m*k matrix
         bh_view* A = &instr->operand[1];

--- a/extmethods/clblas/templates/body.tpl
+++ b/extmethods/clblas/templates/body.tpl
@@ -17,7 +17,7 @@ public:
         cl_command_queue queue = engine->getCQueue();
 
         // All matrices must be contigous
-        assert(instr->is_contiguous());
+        assert(instr->isContiguous());
 
         // A is a m*k matrix
         bh_view* A = &instr->operand[1];

--- a/extmethods/lapack/drivers/le/body.tpl
+++ b/extmethods/lapack/drivers/le/body.tpl
@@ -2,7 +2,7 @@ struct @!uname!@Impl : public ExtmethodImpl {
 public:
     void execute(bh_instruction *instr, void* arg) {
         // All matrices must be contigous
-        assert(instr->is_contiguous());
+        assert(instr->isContiguous());
 
         // B is a n-by-nrhs matrix
         bh_view* B = &instr->operand[2];

--- a/extmethods/opencv/filtering.cpp
+++ b/extmethods/opencv/filtering.cpp
@@ -31,7 +31,7 @@ class ErodeImpl : public ExtmethodImpl {
 public:
     void execute(bh_instruction *instr, void* arg) {
         // All matrices must be contigous
-        assert(instr->is_contiguous());
+        assert(instr->isContiguous());
 
         // A is our image
         bh_view* A = &instr->operand[1];
@@ -95,7 +95,7 @@ class DilateImpl : public ExtmethodImpl {
 public:
     void execute(bh_instruction *instr, void* arg) {
         // All matrices must be contigous
-        assert(instr->is_contiguous());
+        assert(instr->isContiguous());
 
         // A is our image
         bh_view* A = &instr->operand[1];
@@ -160,7 +160,7 @@ class ConnectedComponentsImpl : public ExtmethodImpl {
 public:
     void execute(bh_instruction *instr, void* arg) {
         // All matrices must be contigous
-        assert(instr->is_contiguous());
+        assert(instr->isContiguous());
 
         // A is our image
         bh_view* A = &instr->operand[1];

--- a/extmethods/opencv/templates/threshold/body.tpl
+++ b/extmethods/opencv/templates/threshold/body.tpl
@@ -1,7 +1,7 @@
 struct @!uname!@Impl : public ExtmethodImpl {
 public:
     void execute(bh_instruction *instr, void* arg) {
-        assert(instr->is_contiguous());
+        assert(instr->isContiguous());
 
         // A is our image
         bh_view* A = &instr->operand[1];

--- a/filter/bccon/contract_collect.cpp
+++ b/filter/bccon/contract_collect.cpp
@@ -173,7 +173,7 @@ static void rewrite_chain(BhIR &bhir, vector<bh_instruction*>& chain)
     }
 }
 
-void Contracter::contract_collect(BhIR &bhir)
+void Contracter::collect(BhIR &bhir)
 {
     bh_opcode collect_opcode = BH_NONE;
     vector<const bh_view*> views;

--- a/filter/bccon/contract_muladd.cpp
+++ b/filter/bccon/contract_muladd.cpp
@@ -109,7 +109,7 @@ or in the case of our byte-code:
   BH_MULTIPLY a3 5 a0
 */
 
-void Contracter::contract_muladd(BhIR &bhir)
+void Contracter::muladd(BhIR &bhir)
 {
     bool rewritten = false;
 

--- a/filter/bccon/contract_reduction.cpp
+++ b/filter/bccon/contract_reduction.cpp
@@ -43,7 +43,7 @@ static void rewrite_chain(vector<bh_instruction*>& links, bh_instruction* &first
     }
 }
 
-void Contracter::contract_reduction(BhIR &bhir)
+void Contracter::reduction(BhIR &bhir)
 {
     bh_opcode reduce_opcode = BH_NONE;
     bh_instruction* first;

--- a/filter/bccon/contract_stupidmath.cpp
+++ b/filter/bccon/contract_stupidmath.cpp
@@ -72,7 +72,7 @@ static inline bool is_doing_stupid_math(const bh_instruction& instr)
            is_entire_view(instr);
 }
 
-void Contracter::contract_stupidmath(BhIR &bhir)
+void Contracter::stupidmath(BhIR &bhir)
 {
     for(bh_instruction& instr: bhir.instr_list) {
         if (is_doing_stupid_math(instr)) {

--- a/filter/bccon/contracter.cpp
+++ b/filter/bccon/contracter.cpp
@@ -45,10 +45,10 @@ Contracter::~Contracter(void) {}
 
 void Contracter::contract(BhIR& bhir)
 {
-    if(reduction_)  contract_reduction(bhir);
-    if(stupidmath_) contract_stupidmath(bhir);
-    if(collect_)    contract_collect(bhir);
-    if(muladd_)     contract_muladd(bhir);
+    if(reduction_)  reduction(bhir);
+    if(stupidmath_) stupidmath(bhir);
+    if(collect_)    collect(bhir);
+    if(muladd_)     muladd(bhir);
 }
 
 void verbose_print(std::string str)

--- a/filter/bccon/contracter.hpp
+++ b/filter/bccon/contracter.hpp
@@ -18,10 +18,10 @@ public:
 
     void contract(BhIR& bhir);
 
-    void contract_reduction(BhIR& bhir);
-    void contract_stupidmath(BhIR& bhir);
-    void contract_collect(BhIR& bhir);
-    void contract_muladd(BhIR& bhir);
+    void reduction(BhIR& bhir);
+    void stupidmath(BhIR& bhir);
+    void collect(BhIR& bhir);
+    void muladd(BhIR& bhir);
 private:
     bool repeats_;
     bool reduction_;

--- a/filter/bcexp/expand_powk.cpp
+++ b/filter/bcexp/expand_powk.cpp
@@ -28,7 +28,7 @@ namespace bcexp {
 
 static const int64_t max_exponent_unfolding = 100;
 
-int Expander::expand_powk(BhIR& bhir, int pc)
+int Expander::expandPowk(BhIR& bhir, int pc)
 {
     verbose_print("[Powk] Expanding BH_POWER");
 

--- a/filter/bcexp/expand_reduce1d.cpp
+++ b/filter/bcexp/expand_reduce1d.cpp
@@ -39,7 +39,7 @@ static inline int find_fold(int64_t elements, int thread_limit)
 }
 
 // TODO: What does this do? Give example like expand_sign.cpp
-int Expander::expand_reduce1d(BhIR& bhir, int pc, int thread_limit)
+int Expander::expandReduce1d(BhIR& bhir, int pc, int thread_limit)
 {
     int start_pc = pc;
     bh_instruction& instr = bhir.instr_list[pc];
@@ -78,7 +78,7 @@ int Expander::expand_reduce1d(BhIR& bhir, int pc, int thread_limit)
     in.stride[1] = in.stride[0];
     in.stride[0] = in.stride[0] * elements / fold;
 
-    bh_view temp = make_temp(in.base->type, elements/fold);
+    bh_view temp = createTemp(in.base->type, elements/fold);
 
     inject(bhir, ++pc, opcode,  temp, in,   0, bh_type::INT64);
     inject(bhir, ++pc, opcode,  out,  temp, 0, bh_type::INT64);

--- a/filter/bcexp/expand_sign.cpp
+++ b/filter/bcexp/expand_sign.cpp
@@ -65,7 +65,7 @@ namespace bcexp {
  *
  *  Returns the number of instructions used (12 or 17).
  */
-int Expander::expand_sign(BhIR& bhir, int pc)
+int Expander::expandSign(BhIR& bhir, int pc)
 {
     int start_pc = pc;
     bh_instruction& composite = bhir.instr_list[pc];
@@ -97,9 +97,9 @@ int Expander::expand_sign(BhIR& bhir, int pc)
         verbose_print("[Sign] Expanding complex sign");
         // For non-complex: sign(x) = (x>0)-(x<0)
         // Temps
-        bh_view lss    = make_temp(meta, input_type, nelements);
-        bh_view gtr    = make_temp(meta, input_type, nelements);
-        bh_view t_bool = make_temp(meta, bh_type::BOOL,    nelements);
+        bh_view lss    = createTemp(meta, input_type, nelements);
+        bh_view gtr    = createTemp(meta, input_type, nelements);
+        bh_view t_bool = createTemp(meta, bh_type::BOOL,    nelements);
 
         // Sequence
         inject(bhir, ++pc, BH_GREATER,  t_bool, input, 0.0);
@@ -120,9 +120,9 @@ int Expander::expand_sign(BhIR& bhir, int pc)
 
         // General form: sign(z) = z/(|z|+(z==0))
         // Temps
-        bh_view f_abs  = make_temp(meta, float_type, nelements);
-        bh_view b_zero = make_temp(meta, bh_type::BOOL,    nelements);
-        bh_view f_zero = make_temp(meta, float_type, nelements);
+        bh_view f_abs  = createTemp(meta, float_type, nelements);
+        bh_view b_zero = createTemp(meta, bh_type::BOOL,    nelements);
+        bh_view f_zero = createTemp(meta, float_type, nelements);
 
         // Sequence
         inject(bhir, ++pc, BH_ABSOLUTE, f_abs,  input);

--- a/filter/bcexp/expander.cpp
+++ b/filter/bcexp/expander.cpp
@@ -49,7 +49,7 @@ void Expander::expand(BhIR& bhir)
 
         case BH_POWER:
             if (powk_) {
-                increase = expand_powk(bhir, pc);
+                increase = expandPowk(bhir, pc);
                 end += increase;
                 pc += increase;
             }
@@ -57,7 +57,7 @@ void Expander::expand(BhIR& bhir)
 
         case BH_SIGN:
             if (sign_) {
-                increase = expand_sign(bhir, pc);
+                increase = expandSign(bhir, pc);
                 end += increase;
                 pc += increase;
             }
@@ -75,7 +75,7 @@ void Expander::expand(BhIR& bhir)
         case BH_BITWISE_XOR_REDUCE:
             if (reduce1d_ && instr.operand[1].ndim == 1)
             {
-                increase = expand_reduce1d(bhir, pc, reduce1d_);
+                increase = expandReduce1d(bhir, pc, reduce1d_);
                 end += increase;
                 pc += increase;
             }
@@ -102,15 +102,15 @@ size_t Expander::gc(void)
     return collected;
 }
 
-bh_base* Expander::make_base(bh_type type, int64_t nelem)
+bh_base* Expander::createBase(bh_type type, int64_t nelem)
 {
     bh_base* base = NULL;
     try {
         base = new bh_base;
     } catch (std::bad_alloc& ba) {
         base = NULL;
-        fprintf(stderr, "Expander::make_base(...) bh_base allocation failed.\n");
-        throw std::runtime_error("Expander::make_base(...) bh_base allocation failed.\n");
+        fprintf(stderr, "Expander::createBase(...) bh_base allocation failed.\n");
+        throw std::runtime_error("Expander::createBase(...) bh_base allocation failed.\n");
     }
 
     base->type = type;
@@ -121,17 +121,17 @@ bh_base* Expander::make_base(bh_type type, int64_t nelem)
     return base;
 }
 
-bh_view Expander::make_temp(bh_view& meta, bh_type type, int64_t nelem)
+bh_view Expander::createTemp(bh_view& meta, bh_type type, int64_t nelem)
 {
     bh_view view = meta;
-    view.base = make_base(type, nelem);
+    view.base = createBase(type, nelem);
     return view;
 }
 
-bh_view Expander::make_temp(bh_type type, int64_t nelem)
+bh_view Expander::createTemp(bh_type type, int64_t nelem)
 {
     bh_view view;
-    view.base = make_base(type, nelem);
+    view.base = createBase(type, nelem);
     view.start = 0;
     view.ndim = 1;
     view.shape[0] = nelem;

--- a/filter/bcexp/expander.hpp
+++ b/filter/bcexp/expander.hpp
@@ -49,9 +49,9 @@ public:
      *
      * @return Pointer to the created base.
      */
-    bh_base* make_base(bh_type type, int64_t nelem);
-    bh_view make_temp(bh_view& meta, bh_type type, int64_t nelem);
-    bh_view make_temp(bh_type type, int64_t nelem);
+    bh_base* createBase(bh_type type, int64_t nelem);
+    bh_view createTemp(bh_view& meta, bh_type type, int64_t nelem);
+    bh_view createTemp(bh_type type, int64_t nelem);
 
     /**
      *  Inject an instruction.
@@ -79,10 +79,10 @@ public:
     template <typename T>
     inline void inject(BhIR& bhir, int pc, bh_opcode opcode, bh_view& out, bh_view& in1, T in2);
 
-    int expand_sign(BhIR& bhir, int pc);
-    int expand_powk(BhIR& bhir, int pc);
-    int expand_reduce1d(BhIR& bhir, int pc, int fold_limit);
-    int expand_repeat(BhIR& bhir, int pc);
+    int expandSign(BhIR& bhir, int pc);
+    int expandPowk(BhIR& bhir, int pc);
+    int expandReduce1d(BhIR& bhir, int pc, int fold_limit);
+    int expandRepeat(BhIR& bhir, int pc);
 
 private:
     static const char TAG[];

--- a/include/StaticStore.hpp
+++ b/include/StaticStore.hpp
@@ -53,7 +53,7 @@ class StaticStore
     template <typename... As>
     T* next(As... as);
 #endif
-    T* c_next();
+    T* cNext();
 };
 
 
@@ -92,7 +92,7 @@ StaticStore<T>::~StaticStore()
 }
 
 template <typename T>
-T* StaticStore<T>::c_next()
+T* StaticStore<T>::cNext()
 {
     counter++;
     if (!emptySlot.empty())
@@ -133,7 +133,7 @@ template <typename T>
 template <typename... As>
 T* StaticStore<T>::next(As... as)
 {
-	return new(c_next()) T(as...);
+	return new(cNext()) T(as...);
 }
 #endif
 

--- a/include/bh_component.hpp
+++ b/include/bh_component.hpp
@@ -92,7 +92,7 @@ class ComponentImpl {
      * @return       The data pointer (NB: might point to device memory)
      * Throws exceptions on error
      */
-    virtual void* get_mem_ptr(bh_base &base, bool copy2host, bool force_alloc, bool nullify) = 0;
+    virtual void* getMemoryPointer(bh_base &base, bool copy2host, bool force_alloc, bool nullify) = 0;
 
     /* Set data pointer in the first VE in the runtime stack
      * NB: The component will deallocate the memory when encountering a BH_FREE.
@@ -103,7 +103,7 @@ class ComponentImpl {
      * @mem       The data pointer
      * Throws exceptions on error
      */
-    virtual void set_mem_ptr(bh_base *base, bool host_ptr, void *mem) = 0;
+    virtual void setMemoryPointer(bh_base *base, bool host_ptr, void *mem) = 0;
 
     /* Get the device handle, such as OpenCL's cl_context, of the first VE in the runtime stack.
      * If the first VE isn't a device, NULL is returned.
@@ -111,7 +111,7 @@ class ComponentImpl {
      * @return  The device handle
      * Throws exceptions on error
      */
-    virtual void* get_device_context() = 0;
+    virtual void* getDeviceContext() = 0;
 
     /* Set the device context, such as CUDA's context, of the first VE in the runtime stack.
      * If the first VE isn't a device, nothing happens
@@ -119,7 +119,7 @@ class ComponentImpl {
      * @device_context  The new device context
      * Throws exceptions on error
      */
-    virtual void set_device_context(void* device_context) = 0;
+    virtual void setDeviceContext(void* device_context) = 0;
 };
 
 // Representation of a component interface, which consist of a create()
@@ -157,21 +157,21 @@ class ComponentFace {
         assert(_implementation != NULL);
         return _implementation->message(msg);
     }
-    void* get_mem_ptr(bh_base &base, bool copy2host, bool force_alloc, bool nullify) {
+    void* getMemoryPointer(bh_base &base, bool copy2host, bool force_alloc, bool nullify) {
         assert(_implementation != NULL);
-        return _implementation->get_mem_ptr(base, copy2host, force_alloc, nullify);
+        return _implementation->getMemoryPointer(base, copy2host, force_alloc, nullify);
     }
-    virtual void set_mem_ptr(bh_base *base, bool host_ptr, void *mem) {
+    virtual void setMemoryPointer(bh_base *base, bool host_ptr, void *mem) {
         assert(_implementation != NULL);
-        return _implementation->set_mem_ptr(base, host_ptr, mem);
+        return _implementation->setMemoryPointer(base, host_ptr, mem);
     }
-    void* get_device_context() {
+    void* getDeviceContext() {
         assert(_implementation != NULL);
-        return _implementation->get_device_context();
+        return _implementation->getDeviceContext();
     };
-    void set_device_context(void* device_context) {
+    void setDeviceContext(void* device_context) {
         assert(_implementation != NULL);
-        _implementation->set_device_context(device_context);
+        _implementation->setDeviceContext(device_context);
     };
 };
 
@@ -201,17 +201,17 @@ public:
     virtual std::string message(const std::string &msg) {
         return child.message(msg);
     }
-    virtual void* get_mem_ptr(bh_base &base, bool copy2host, bool force_alloc, bool nullify) {
-        return child.get_mem_ptr(base, copy2host, force_alloc, nullify);
+    virtual void* getMemoryPointer(bh_base &base, bool copy2host, bool force_alloc, bool nullify) {
+        return child.getMemoryPointer(base, copy2host, force_alloc, nullify);
     };
-    virtual void set_mem_ptr(bh_base *base, bool host_ptr, void *mem) {
-        return child.set_mem_ptr(base, host_ptr, mem);
+    virtual void setMemoryPointer(bh_base *base, bool host_ptr, void *mem) {
+        return child.setMemoryPointer(base, host_ptr, mem);
     }
-    virtual void* get_device_context() {
-        return child.get_device_context();
+    virtual void* getDeviceContext() {
+        return child.getDeviceContext();
     };
-    virtual void set_device_context(void* device_context) {
-        child.set_device_context(device_context);
+    virtual void setDeviceContext(void* device_context) {
+        child.setDeviceContext(device_context);
     };
 };
 

--- a/include/bh_config_parser.hpp
+++ b/include/bh_config_parser.hpp
@@ -259,8 +259,4 @@ inline boost::filesystem::path ConfigParser::get(const std::string &section, con
     }
 }
 
-
-
-
-
 } //namespace bohrium

--- a/include/bh_instruction.hpp
+++ b/include/bh_instruction.hpp
@@ -82,7 +82,7 @@ struct bh_instruction
     }
 
     // Check if all views in this instruction is contiguous
-    bool is_contiguous() const;
+    bool isContiguous() const;
 
     // Check if all view in this instruction have the same shape
     bool all_same_shape() const;

--- a/include/bh_ir.hpp
+++ b/include/bh_ir.hpp
@@ -42,18 +42,21 @@ public:
 
 public:
     /** The regular constructor that takes the instructions, the sync'ed arrays, and number of times to run the BhIR */
-    BhIR(std::vector<bh_instruction> instr_list, std::set<bh_base *> syncs,
-         uint64_t nrepeats = 1, bh_base *repeat_condition = nullptr) : instr_list(std::move(instr_list)),
-                                                                       _syncs(std::move(syncs)),
-                                                                       _nrepeats(nrepeats),
-                                                                       _repeat_condition(repeat_condition) {}
+    BhIR(std::vector<bh_instruction> instr_list,
+         std::set<bh_base *> syncs,
+         uint64_t nrepeats = 1,
+         bh_base *repeat_condition = nullptr) :
+        instr_list(std::move(instr_list)),
+        _syncs(std::move(syncs)),
+        _nrepeats(nrepeats),
+        _repeat_condition(repeat_condition) {}
 
     /** Constructor that takes a serialized archive. All base array pointers are updated so that they point to
      *  local base arrays in `remote2local`.
      *
      *
      * \param serialized_archive Byte vector that makes up the serialized archive. The archive should be created with
-     *                           `write_serialized_archive`, which uses `boost::archive::binary_iarchive`.
+     *                           `writeSerializedArchive`, which uses `boost::archive::binary_iarchive`.
      *
      * \param remote2local Map that maps remote array bases to local bases. The map is updated to include the new
      *                     array bases encountered in this BhIR thus this map should stay allocated throughout the
@@ -67,8 +70,10 @@ public:
      *       Use `remote2local` to translate remote base arrays to local base arrays, which are regular base arrays
      *       that can dereferenced.
      */
-    BhIR(const std::vector<char> &serialized_archive, std::map<const bh_base*, bh_base> &remote2local,
-         std::vector<bh_base*> &data_recv, std::set<bh_base*> &frees);
+    BhIR(const std::vector<char> &serialized_archive,
+         std::map<const bh_base*, bh_base> &remote2local,
+         std::vector<bh_base*> &data_recv,
+         std::set<bh_base*> &frees);
 
 
     /** Write the BhIR into a serialized archive.
@@ -81,8 +86,7 @@ public:
      *                 in the BhIR, thus their data should be transferred to the de-serializing component in the order
      *                 they appear.
      */
-    std::vector<char> write_serialized_archive(std::set<bh_base *> &known_base_arrays,
-                                               std::vector<bh_base *> &new_data);
+    std::vector<char> writeSerializedArchive(std::set<bh_base*> &known_base_arrays, std::vector<bh_base*> &new_data);
 
     /** Returns the set of sync'ed arrays */
     const std::set<bh_base *> getSyncs() const {

--- a/include/jitk/block.hpp
+++ b/include/jitk/block.hpp
@@ -77,7 +77,7 @@ public:
     bool isInnermost() const;
 
     // Return all sub-blocks (incl. nested blocks)
-    void getAllSubBlocks(std::vector<const LoopB *> &out) const;
+    void getAllSubBlocks(std::vector<const LoopB*> &out) const;
 
     // Return all sub-blocks (excl. nested blocks)
     std::vector<const LoopB*> getLocalSubBlocks() const;
@@ -135,7 +135,7 @@ public:
     // Insert the system instruction 'instr' after the instruction that accesses 'base' last.
     // If no instruction accesses 'base' we insert it after the last instruction.
     // NB: Force reshape the instruction to match the instructions accesses 'base' last.
-    void insert_system_after(InstrPtr instr, const bh_base *base);
+    void insertSystemAfter(InstrPtr instr, const bh_base *base);
 
     // Returns the amount of threading in this block (excl. nested blocks)
     uint64_t localThreading() const;
@@ -144,7 +144,7 @@ public:
     std::string pprint(const char *newline="\n") const;
 
     // Updates the metadata such as the sets of sweeps, news, frees etc.
-    void metadata_update();
+    void metadataUpdate();
 
     // Equality test based on the unique ID
     bool operator==(const LoopB &loop_block) const {
@@ -256,7 +256,7 @@ public:
     }
 
     // Determines whether this block must be executed after 'other'
-    bool depend_on(const Block &other) const {
+    bool dependOn(const Block &other) const {
         const std::vector<InstrPtr> this_instr_list = getAllInstr();
         const std::vector<InstrPtr> other_instr_list = other.getAllInstr();
         for (const InstrPtr this_instr: this_instr_list) {
@@ -287,7 +287,7 @@ Block create_nested_block(const std::vector<InstrPtr> &instr_list, int rank, int
 
 // Returns the blocks that can be parallelized in 'block' (incl. 'block' and its sub-blocks)
 // and the total amount of parallelism (in number of possible parallel threads)
-std::pair<std::vector<const LoopB *>, uint64_t> util_find_threaded_blocks(const LoopB &block);
+std::pair<std::vector<const LoopB*>, uint64_t> util_find_threaded_blocks(const LoopB &block);
 
 // Check if the two blocks 'b1' and 'b2' (in that order) are mergeable.
 // 'avoid_rank0_sweep' will not allow fusion of sweeped and non-sweeped blocks at the root level

--- a/include/jitk/statistics.hpp
+++ b/include/jitk/statistics.hpp
@@ -111,7 +111,7 @@ class Statistics {
         if (filename == "") {
             pprint(backend_name, out);
         } else {
-            export_yaml(backend_name, filename);
+            exportYAML(backend_name, filename);
         }
     }
 
@@ -123,17 +123,17 @@ class Statistics {
             wallclock = chrono::steady_clock::now() - time_started;
 
             out << BLU << "[" << backend_name << "] Profiling: \n" << RST;
-            out << "Fuse cache hits:                 " << GRN << fuse_cache_hits()                   << "\n" << RST;
-            out << "Codegen cache hits               " << GRN << codegen_cache_hits()                << "\n" << RST;
-            out << "Kernel cache hits                " << GRN << kernel_cache_hits()                 << "\n" << RST;
-            out << "Array contractions:              " << GRN << array_contractions()                << "\n" << RST;
-            out << "Outer-fusion ratio:              " << GRN << outer_fusion_ratio()                << "\n" << RST;
+            out << "Fuse cache hits:                 " << GRN << fuseCacheHits()                     << "\n" << RST;
+            out << "Codegen cache hits               " << GRN << codegenCacheHits()                  << "\n" << RST;
+            out << "Kernel cache hits                " << GRN << kernelCacheHits()                   << "\n" << RST;
+            out << "Array contractions:              " << GRN << arrayContractions()                 << "\n" << RST;
+            out << "Outer-fusion ratio:              " << GRN << outerFusionRatio()                  << "\n" << RST;
             out << "\n";
-            out << "Max memory usage:                " << GRN << memory_usage() << " MB"             << "\n" << RST;
+            out << "Max memory usage:                " << GRN << memoryUsage() << " MB"              << "\n" << RST;
             out << "Syncs to NumPy:                  " << GRN << num_syncs                           << "\n" << RST;
             out << "Total Work:                      " << GRN << totalwork << " operations"          << "\n" << RST;
             out << "Throughput:                      " << GRN << throughput() << "ops"               << "\n" << RST;
-            out << "Work below par-threshold (1000): " << GRN << work_below_thredshold() << "%"      << "\n" << RST;
+            out << "Work below par-threshold (1000): " << GRN << workBelowThredshold() << "%"        << "\n" << RST;
             out << "\n";
             out << "Wall clock:                      " << BLU << wallclock.count() << "s"            << "\n" << RST;
             out << "Total Execution:                 " << BLU << time_total_execution.count() << "s" << "\n" << RST;
@@ -146,7 +146,7 @@ class Statistics {
             out << "  Copy2host:                     " << YEL << time_copy2host.count() << "s"       << "\n" << RST;
             out << "  Ext-method:                    " << YEL << time_ext_method.count() << "s"      << "\n" << RST;
             out << "  Offload:                       " << YEL << time_offload.count() << "s"         << "\n" << RST;
-            out << "  Other:                         " << YEL << time_other() << "s"                 << "\n" << RST;
+            out << "  Other:                         " << YEL << timeOther() << "s"                  << "\n" << RST;
             out << "\n";
             out << BOLD << RED << "Unaccounted for (wall - total):  " << unaccounted() << "s\n" << RST;
 
@@ -170,7 +170,7 @@ class Statistics {
                 out << "  "
                     << std::left         << std::setw(39) << kernel_filename
                     << std::right << YEL << std::setw(10) << kernel_data.num_calls         << "    "
-                    << std::scientific << std::setprecision(2)
+                    << std::scientific   << std::setprecision(2)
                                          << std::setw(8) << kernel_data.total_time.count() << "s   "
                                          << std::setw(8) << kernel_data.max_time.count()   << "s   "
                                          << std::setw(8) << kernel_data.min_time.count()   << "s   " << "\n" << RST;
@@ -184,7 +184,7 @@ class Statistics {
     }
 
     // Export statistic using the YAML format <http://yaml.org>
-    void export_yaml(std::string backend_name, std::string filename) {
+    void exportYAML(std::string backend_name, std::string filename) {
         using namespace std;
 
         if (enabled) {
@@ -195,16 +195,16 @@ class Statistics {
 
             file << "----"                                                           << "\n";
             file << backend_name << ":"                                              << "\n";
-            file << "  fuse_cache_hits: "       << fuse_cache_hits()                 << "\n";
-            file << "  codegen_cache_hits: "    << codegen_cache_hits()              << "\n";
-            file << "  kernel_cache_hits: "     << kernel_cache_hits()               << "\n";
-            file << "  array_contractions: "    << array_contractions()              << "\n";
-            file << "  outer_fusion_ratio: "    << outer_fusion_ratio()              << "\n";
-            file << "  memory_usage: "          << memory_usage()                    << "\n"; // mb
+            file << "  fuse_cache_hits: "       << fuseCacheHits()                   << "\n";
+            file << "  codegen_cache_hits: "    << codegenCacheHits()                << "\n";
+            file << "  kernel_cache_hits: "     << kernelCacheHits()                 << "\n";
+            file << "  array_contractions: "    << arrayContractions()               << "\n";
+            file << "  outer_fusion_ratio: "    << outerFusionRatio()                << "\n";
+            file << "  memory_usage: "          << memoryUsage()                     << "\n"; // mb
             file << "  syncs: "                 << num_syncs                         << "\n";
             file << "  total_work: "            << totalwork                         << "\n"; // ops
             file << "  throughput: "            << throughput()                      << "\n"; // ops
-            file << "  work_below_thredshold: " << work_below_thredshold()           << "\n"; // %
+            file << "  work_below_thredshold: " << workBelowThredshold()             << "\n"; // %
             file << "  timing:"                                                      << "\n";
             file << "    wall_clock: "          << wallclock.count()                 << "\n"; // s
             file << "    total_execution: "     << time_total_execution.count()      << "\n"; // s
@@ -227,7 +227,7 @@ class Statistics {
             file << "    copy2dev: "            << time_copy2dev.count()             << "\n"; // s
             file << "    copy2host: "           << time_copy2host.count()            << "\n"; // s
             file << "    offload: "             << time_offload.count()              << "\n"; // s
-            file << "    other: "               << time_other()                      << "\n"; // s
+            file << "    other: "               << timeOther()                       << "\n"; // s
             file << "    unaccounted: "         << unaccounted()                     << "\n"; // s
             file.close();
         }
@@ -252,32 +252,32 @@ class Statistics {
       num_temp_arrays += symbols.getNumBaseArrays() - symbols.getParams().size();
     }
 
-    void add_kernel(const std::string& kernel_name) {
+    void addKernel(const std::string& kernel_name) {
       time_per_kernel.insert(std::make_pair(kernel_name, KernelStats()));
     }
 
   private:
-    std::string fuse_cache_hits() {
+    std::string fuseCacheHits() {
         return pprint_ratio(fuser_cache_lookups - fuser_cache_misses, fuser_cache_lookups);
     }
 
-    std::string codegen_cache_hits() {
+    std::string codegenCacheHits() {
         return pprint_ratio(codegen_cache_lookups - codegen_cache_misses, codegen_cache_lookups);
     }
 
-    std::string kernel_cache_hits() {
+    std::string kernelCacheHits() {
         return pprint_ratio(kernel_cache_lookups - kernel_cache_misses, kernel_cache_lookups);
     }
 
-    std::string array_contractions() {
+    std::string arrayContractions() {
         return pprint_ratio(num_temp_arrays, num_base_arrays);
     }
 
-    std::string outer_fusion_ratio() {
+    std::string outerFusionRatio() {
         return pprint_ratio(num_blocks_out_of_fuser, num_instrs_into_fuser);
     }
 
-    double memory_usage() {
+    double memoryUsage() {
         return (double) max_memory_usage / 1024.0 / 1024.0;
     }
 
@@ -285,11 +285,11 @@ class Statistics {
         return (double) totalwork / (double) wallclock.count();
     }
 
-    double work_below_thredshold() {
+    double workBelowThredshold() {
         return (double) threading_below_threshold / (double) totalwork * 100.0;
     }
 
-    double time_other() {
+    double timeOther() {
         std::chrono::duration<double> time_other{0};
         return (time_total_execution - time_pre_fusion - time_fusion - time_codegen - time_compile - time_exec
                 - time_copy2dev - time_copy2host - time_offload).count();

--- a/ve/cuda/main.cpp
+++ b/ve/cuda/main.cpp
@@ -74,7 +74,7 @@ class Impl : public ComponentImplWithChild {
         } else if (msg == "statistic") {
             stat.write("CUDA", "", ss);
         } else if (msg == "GPU: disable") {
-            engine.allBasesToHost();
+            engine.copyAllBasesToHost();
             disabled = true;
         } else if (msg == "GPU: enable") {
             disabled = false;
@@ -87,7 +87,7 @@ class Impl : public ComponentImplWithChild {
     }
 
     // Handle memory pointer retrieval
-    void* get_mem_ptr(bh_base &base, bool copy2host, bool force_alloc, bool nullify) {
+    void* getMemoryPointer(bh_base &base, bool copy2host, bool force_alloc, bool nullify) {
         bh_base *b = &base;
         if (copy2host) {
             std::set <bh_base*> t = { b };
@@ -129,10 +129,10 @@ void Impl::execute(BhIR *bhir) {
     bh_base *cond = bhir->getRepeatCondition();
     for (uint64_t i=0; i < bhir->getNRepeats(); ++i) {
         // Let's handle extension methods
-        engine.handle_extmethod(*this, bhir, child_extmethods);
+        engine.handleExtmethod(*this, bhir, child_extmethods);
 
         // And then the regular instructions
-        engine.handle_execution(*this, bhir);
+        engine.handleExecution(*this, bhir);
 
         // Check condition
         if (cond != nullptr) {

--- a/ve/opencl/engine_opencl.hpp
+++ b/ve/opencl/engine_opencl.hpp
@@ -79,32 +79,32 @@ public:
     void copyToDevice(const std::set<bh_base*> &base_list) override;
 
     // Sets the constructor flag of each instruction in 'instr_list'
-    void set_constructor_flag(std::vector<bh_instruction*> &instr_list) override;
+    void setConstructorFlag(std::vector<bh_instruction*> &instr_list) override;
 
     // Copy all bases to the host (ignoring bases that isn't on the device)
-    void allBasesToHost() override;
+    void copyAllBasesToHost() override;
 
     // Delete a buffer
     void delBuffer(bh_base* &base) override;
 
-    void write_kernel(const jitk::Block &block,
-                      const jitk::SymbolTable &symbols,
-                      const std::vector<const jitk::LoopB*> &threaded_blocks,
-                      std::stringstream &ss) override;
+    void writeKernel(const jitk::Block &block,
+                     const jitk::SymbolTable &symbols,
+                     const std::vector<const jitk::LoopB*> &threaded_blocks,
+                     std::stringstream &ss) override;
 
     // Writes the OpenCL specific for-loop header
-    void loop_head_writer(const jitk::SymbolTable &symbols,
-                          jitk::Scope &scope,
-                          const jitk::LoopB &block,
-                          bool loop_is_peeled,
-                          const std::vector<const jitk::LoopB *> &threaded_blocks,
-                          std::stringstream &out) override;
+    void loopHeadWriter(const jitk::SymbolTable &symbols,
+                        jitk::Scope &scope,
+                        const jitk::LoopB &block,
+                        bool loop_is_peeled,
+                        const std::vector<const jitk::LoopB*> &threaded_blocks,
+                        std::stringstream &out) override;
 
     // Return a YAML string describing this component
     std::string info() const override;
 
     // Return OpenCL API types, which are used inside the JIT kernels
-    const std::string write_type(bh_type dtype) override;
+    const std::string writeType(bh_type dtype) override;
 
     cl::Buffer *createBuffer(bh_base *base) {
         cl::Buffer *buf = new cl::Buffer(context, CL_MEM_READ_WRITE, (cl_ulong) bh_base_size(base));

--- a/ve/opencl/main.cpp
+++ b/ve/opencl/main.cpp
@@ -72,7 +72,7 @@ class Impl : public ComponentImplWithChild {
         } else if (msg == "statistic") {
             stat.write("OpenCL", "", ss);
         } else if (msg == "GPU: disable") {
-            engine.allBasesToHost();
+            engine.copyAllBasesToHost();
             disabled = true;
         } else if (msg == "GPU: enable") {
             disabled = false;
@@ -83,7 +83,7 @@ class Impl : public ComponentImplWithChild {
     }
 
     // Handle memory pointer retrieval
-    void* get_mem_ptr(bh_base &base, bool copy2host, bool force_alloc, bool nullify) {
+    void* getMemoryPointer(bh_base &base, bool copy2host, bool force_alloc, bool nullify) {
         bh_base *b = &base;
         if (copy2host) {
             std::set<bh_base*> t = { b };
@@ -103,7 +103,7 @@ class Impl : public ComponentImplWithChild {
     }
 
     // Handle memory pointer obtainment
-    void set_mem_ptr(bh_base *base, bool host_ptr, void *mem) {
+    void setMemoryPointer(bh_base *base, bool host_ptr, void *mem) {
         if (host_ptr) {
             std::set<bh_base*> t = { base };
             engine.copyToHost(t);
@@ -115,7 +115,7 @@ class Impl : public ComponentImplWithChild {
     }
 
     // Handle the OpenCL context retrieval
-    void* get_device_context() {
+    void* getDeviceContext() {
         return engine.getCContext();
     };
 };
@@ -144,10 +144,10 @@ void Impl::execute(BhIR *bhir) {
     bh_base *cond = bhir->getRepeatCondition();
     for (uint64_t i = 0; i < bhir->getNRepeats(); ++i) {
         // Let's handle extension methods
-        engine.handle_extmethod(*this, bhir, child_extmethods);
+        engine.handleExtmethod(*this, bhir, child_extmethods);
 
         // And then the regular instructions
-        engine.handle_execution(*this, bhir);
+        engine.handleExecution(*this, bhir);
 
         // Check condition
         if (cond != nullptr) {

--- a/ve/openmp/engine_openmp.hpp
+++ b/ve/openmp/engine_openmp.hpp
@@ -40,7 +40,7 @@ namespace bohrium {
 typedef void (*KernelFunction)(void* data_list[], uint64_t offset_strides[], bh_constant_value constants[]);
 
 class EngineOpenMP : public jitk::EngineCPU {
-  private:
+private:
     std::map<uint64_t, KernelFunction> _functions;
     std::vector<void*> _lib_handles;
 
@@ -50,7 +50,7 @@ class EngineOpenMP : public jitk::EngineCPU {
     // Return a kernel function based on the given 'source'
     KernelFunction getFunction(const std::string &source);
 
-  public:
+public:
     EngineOpenMP(const ConfigParser &config, jitk::Statistics &stat);
 
     ~EngineOpenMP();
@@ -60,51 +60,51 @@ class EngineOpenMP : public jitk::EngineCPU {
                  const std::vector<const bh_view*> &offset_strides,
                  const std::vector<const bh_instruction*> &constants) override;
 
-    void set_constructor_flag(std::vector<bh_instruction*> &instr_list) override;
+    void setConstructorFlag(std::vector<bh_instruction*> &instr_list) override;
 
-    void write_kernel(const std::vector<jitk::Block> &block_list,
-                      const jitk::SymbolTable &symbols,
-                      const std::vector<bh_base*> &kernel_temps,
-                      std::stringstream &ss) override;
+    void writeKernel(const std::vector<jitk::Block> &block_list,
+                     const jitk::SymbolTable &symbols,
+                     const std::vector<bh_base*> &kernel_temps,
+                     std::stringstream &ss) override;
 
      // Writing the OpenMP header, which include "parallel for" and "simd"
-    void write_header(const jitk::SymbolTable &symbols,
-                      jitk::Scope &scope,
-                      const jitk::LoopB &block,
-                      std::stringstream &out);
+    void writeHeader(const jitk::SymbolTable &symbols,
+                     jitk::Scope &scope,
+                     const jitk::LoopB &block,
+                     std::stringstream &out);
 
-    void loop_head_writer(const jitk::SymbolTable &symbols,
-                          jitk::Scope &scope,
-                          const jitk::LoopB &block,
-                          bool loop_is_peeled,
-                          const std::vector<const jitk::LoopB *> &threaded_blocks,
-                          std::stringstream &out) override;
+    void loopHeadWriter(const jitk::SymbolTable &symbols,
+                        jitk::Scope &scope,
+                        const jitk::LoopB &block,
+                        bool loop_is_peeled,
+                        const std::vector<const jitk::LoopB*> &threaded_blocks,
+                        std::stringstream &out) override;
 
     // Return a YAML string describing this component
     std::string info() const override;
 
     // Return C99 types, which are used inside the C99 kernels
-    const std::string write_type(bh_type dtype) override;
+    const std::string writeType(bh_type dtype) override;
 
-  private:
+private:
     // Writes the union of C99 types that can make up a constant
-    inline void write_union_type(std::stringstream& out) {
+    inline void writeUnionType(std::stringstream& out) {
         out << "\ntypedef struct { uint64_t x, y; } r123_t" << ";\n";
         out << "union dtype {\n";
-        util::spaces(out, 4); out << write_type(bh_type::BOOL)       << " " << bh_type_text(bh_type::BOOL)       << ";\n";
-        util::spaces(out, 4); out << write_type(bh_type::INT8)       << " " << bh_type_text(bh_type::INT8)       << ";\n";
-        util::spaces(out, 4); out << write_type(bh_type::INT16)      << " " << bh_type_text(bh_type::INT16)      << ";\n";
-        util::spaces(out, 4); out << write_type(bh_type::INT32)      << " " << bh_type_text(bh_type::INT32)      << ";\n";
-        util::spaces(out, 4); out << write_type(bh_type::INT64)      << " " << bh_type_text(bh_type::INT64)      << ";\n";
-        util::spaces(out, 4); out << write_type(bh_type::UINT8)      << " " << bh_type_text(bh_type::UINT8)      << ";\n";
-        util::spaces(out, 4); out << write_type(bh_type::UINT16)     << " " << bh_type_text(bh_type::UINT16)     << ";\n";
-        util::spaces(out, 4); out << write_type(bh_type::UINT32)     << " " << bh_type_text(bh_type::UINT32)     << ";\n";
-        util::spaces(out, 4); out << write_type(bh_type::UINT64)     << " " << bh_type_text(bh_type::UINT64)     << ";\n";
-        util::spaces(out, 4); out << write_type(bh_type::FLOAT32)    << " " << bh_type_text(bh_type::FLOAT32)    << ";\n";
-        util::spaces(out, 4); out << write_type(bh_type::FLOAT64)    << " " << bh_type_text(bh_type::FLOAT64)    << ";\n";
-        util::spaces(out, 4); out << write_type(bh_type::COMPLEX64)  << " " << bh_type_text(bh_type::COMPLEX64)  << ";\n";
-        util::spaces(out, 4); out << write_type(bh_type::COMPLEX128) << " " << bh_type_text(bh_type::COMPLEX128) << ";\n";
-        util::spaces(out, 4); out << write_type(bh_type::R123)       << " " << bh_type_text(bh_type::R123)       << ";\n";
+        util::spaces(out, 4); out << writeType(bh_type::BOOL)       << " " << bh_type_text(bh_type::BOOL)       << ";\n";
+        util::spaces(out, 4); out << writeType(bh_type::INT8)       << " " << bh_type_text(bh_type::INT8)       << ";\n";
+        util::spaces(out, 4); out << writeType(bh_type::INT16)      << " " << bh_type_text(bh_type::INT16)      << ";\n";
+        util::spaces(out, 4); out << writeType(bh_type::INT32)      << " " << bh_type_text(bh_type::INT32)      << ";\n";
+        util::spaces(out, 4); out << writeType(bh_type::INT64)      << " " << bh_type_text(bh_type::INT64)      << ";\n";
+        util::spaces(out, 4); out << writeType(bh_type::UINT8)      << " " << bh_type_text(bh_type::UINT8)      << ";\n";
+        util::spaces(out, 4); out << writeType(bh_type::UINT16)     << " " << bh_type_text(bh_type::UINT16)     << ";\n";
+        util::spaces(out, 4); out << writeType(bh_type::UINT32)     << " " << bh_type_text(bh_type::UINT32)     << ";\n";
+        util::spaces(out, 4); out << writeType(bh_type::UINT64)     << " " << bh_type_text(bh_type::UINT64)     << ";\n";
+        util::spaces(out, 4); out << writeType(bh_type::FLOAT32)    << " " << bh_type_text(bh_type::FLOAT32)    << ";\n";
+        util::spaces(out, 4); out << writeType(bh_type::FLOAT64)    << " " << bh_type_text(bh_type::FLOAT64)    << ";\n";
+        util::spaces(out, 4); out << writeType(bh_type::COMPLEX64)  << " " << bh_type_text(bh_type::COMPLEX64)  << ";\n";
+        util::spaces(out, 4); out << writeType(bh_type::COMPLEX128) << " " << bh_type_text(bh_type::COMPLEX128) << ";\n";
+        util::spaces(out, 4); out << writeType(bh_type::R123)       << " " << bh_type_text(bh_type::R123)       << ";\n";
         out << "};\n";
     }
 };

--- a/ve/openmp/main.cpp
+++ b/ve/openmp/main.cpp
@@ -84,9 +84,9 @@ class Impl : public ComponentImpl {
     }
 
     // Handle memory pointer retrieval
-    void* get_mem_ptr(bh_base &base, bool copy2host, bool force_alloc, bool nullify) {
+    void* getMemoryPointer(bh_base &base, bool copy2host, bool force_alloc, bool nullify) {
         if (not copy2host) {
-            throw runtime_error("OpenMP - get_mem_ptr(): `copy2host` is not True");
+            throw runtime_error("OpenMP - getMemoryPointer(): `copy2host` is not True");
         }
         if (force_alloc) {
             bh_data_malloc(&base);
@@ -99,23 +99,23 @@ class Impl : public ComponentImpl {
     }
 
     // Handle memory pointer obtainment
-    void set_mem_ptr(bh_base *base, bool host_ptr, void *mem) {
+    void setMemoryPointer(bh_base *base, bool host_ptr, void *mem) {
         if (not host_ptr) {
-            throw runtime_error("OpenMP - set_mem_ptr(): `host_ptr` is not True");
+            throw runtime_error("OpenMP - setMemoryPointer(): `host_ptr` is not True");
         }
         if (base->data != nullptr) {
-            throw runtime_error("OpenMP - set_mem_ptr(): `base->data` is not NULL");
+            throw runtime_error("OpenMP - setMemoryPointer(): `base->data` is not NULL");
         }
         base->data = mem;
     }
 
     // We have no context so returning NULL
-    void* get_device_context() {
+    void* getDeviceContext() {
         return nullptr;
     };
 
     // We have no context so doing nothing
-    void set_device_context(void* device_context) {};
+    void setDeviceContext(void* device_context) {};
 };
 }
 
@@ -136,10 +136,10 @@ void Impl::execute(BhIR *bhir) {
     bh_base *cond = bhir->getRepeatCondition();
     for (uint64_t i = 0; i < bhir->getNRepeats(); ++i) {
         // Let's handle extension methods
-        engine.handle_extmethod(*this, bhir);
+        engine.handleExtmethod(*this, bhir);
 
         // And then the regular instructions
-        engine.handle_execution(bhir);
+        engine.handleExecution(bhir);
 
         // Check condition
         if (cond != nullptr and cond->data != nullptr and not ((bool*) cond->data)[0]) {

--- a/vem/proxy/backend.cpp
+++ b/vem/proxy/backend.cpp
@@ -89,7 +89,7 @@ static void service(const std::string &address, int port)
 
                 if (util::exist(remote2local, body.base)) {
                     bh_base &local_base = remote2local.at(body.base);
-                    void *data = child->get_mem_ptr(local_base, true, false, body.nullify);
+                    void *data = child->getMemoryPointer(local_base, true, false, body.nullify);
                     comm_backend.send_array_data(data, bh_base_size(&local_base));
                 } else {
                     comm_backend.send_array_data(nullptr, 0);

--- a/vem/proxy/main.cpp
+++ b/vem/proxy/main.cpp
@@ -54,9 +54,9 @@ public:
     }
 
     // Handle memory pointer retrieval
-    void* get_mem_ptr(bh_base &base, bool copy2host, bool force_alloc, bool nullify) {
+    void* getMemoryPointer(bh_base &base, bool copy2host, bool force_alloc, bool nullify) {
         if (not copy2host) {
-            throw runtime_error("PROXY - get_mem_ptr(): `copy2host` is not True");
+            throw runtime_error("PROXY - getMemoryPointer(): `copy2host` is not True");
         }
 
         // Serialize message body
@@ -89,20 +89,20 @@ public:
     }
 
     // Handle memory pointer obtainment
-    void set_mem_ptr(bh_base *base, bool host_ptr, void *mem) {
+    void setMemoryPointer(bh_base *base, bool host_ptr, void *mem) {
         if (not host_ptr) {
-            throw runtime_error("PROXY - set_mem_ptr(): `host_ptr` is not True");
+            throw runtime_error("PROXY - setMemoryPointer(): `host_ptr` is not True");
         }
-        throw runtime_error("PROXY - set_mem_ptr(): not implemented");
+        throw runtime_error("PROXY - setMemoryPointer(): not implemented");
     }
 
     // We have no context so returning NULL
-    void* get_device_context() {
+    void* getDeviceContext() {
         return nullptr;
     };
 
     // We have no context so doing nothing
-    void set_device_context(void* device_context) {};
+    void setDeviceContext(void* device_context) {};
 };
 } //Unnamed namespace
 
@@ -119,7 +119,7 @@ void Impl::execute(BhIR *bhir) {
 
     // Serialize the BhIR, which becomes the message body
     vector<bh_base *> new_data; // New data in the order they appear in the instruction list
-    vector<char> buf_body = bhir->write_serialized_archive(known_base_arrays, new_data);
+    vector<char> buf_body = bhir->writeSerializedArchive(known_base_arrays, new_data);
 
     // Serialize message head
     vector<char> buf_head;


### PR DESCRIPTION
This solves part of #486.

The reason it only solves part of it, is that `bh_instruction.hpp` and the like actually doesn't create a class but rather a struct. This might be part of #487 to solve that.