### PR TITLE
Fix randn on python 3

### DIFF
--- a/bridge/npbackend/bohrium/random123.pyx
+++ b/bridge/npbackend/bohrium/random123.pyx
@@ -687,7 +687,7 @@ cdef class RandomState:
                 return dtype(z0)
         else:
             length = size if numpy.isscalar(size) else functools.reduce(operator.mul, size)
-            hlength = length / 2 + length % 2
+            hlength = length // 2 + length % 2
             u1 = self.random_sample(size=hlength, dtype=dtype, bohrium=bohrium)
             u2 = self.random_sample(size=hlength, dtype=dtype, bohrium=bohrium)
             r = np.sqrt(-2. * np.log(u1))

--- a/test/python/tests/test_random.py
+++ b/test/python/tests/test_random.py
@@ -1,0 +1,69 @@
+import util
+
+
+class test_random_nontrivial:
+    def init(self):
+        cmd_bh = "R = M.random.RandomState(42); "
+        for shape in [10, (10,), (10, 11)]:
+            cmd_np = "res = np.zeros(%s, dtype=np.bool); " % repr(shape)
+            cmd_np += "res.flat[0] = True; "
+            for dtype in util.TYPES.FLOAT:
+                yield cmd_np, cmd_bh, shape, dtype
+
+    def test_random(self, arg):
+        cmd_np, cmd_bh, shape, dtype = arg
+        cmd_bh += "a = R.random(%s, dtype=%s); " % (shape, dtype)
+        cmd_bh += "res = a == a.flatten()[0]"
+        return cmd_np, cmd_bh
+
+    def test_rand(self, arg):
+        cmd_np, cmd_bh, shape, dtype = arg
+        if isinstance(shape, int):
+            shape = (shape,)
+        cmd_bh += "a = R.rand(*%s, dtype=%s); " % (shape, dtype)
+        cmd_bh += "res = a == a.flatten()[0]"
+        return cmd_np, cmd_bh
+
+    def test_standard_normal(self, arg):
+        cmd_np, cmd_bh, shape, dtype = arg
+        cmd_bh += "a = R.standard_normal(%s, dtype=%s); " % (shape, dtype)
+        cmd_bh += "res = a == a.flatten()[0]"
+        return cmd_np, cmd_bh
+
+    def test_randn(self, arg):
+        cmd_np, cmd_bh, shape, dtype = arg
+        if isinstance(shape, int):
+            shape = (shape,)
+        cmd_bh += "a = R.randn(*%s, dtype=%s); " % (shape, dtype)
+        cmd_bh += "res = a == a.flatten()[0]"
+        return cmd_np, cmd_bh
+
+    def test_standard_exponential(self, arg):
+        cmd_np, cmd_bh, shape, dtype = arg
+        cmd_bh += "a = R.standard_exponential(%s, dtype=%s); " % (shape, dtype)
+        cmd_bh += "res = a == a.flatten()[0]"
+        return cmd_np, cmd_bh
+
+    def test_randint(self, arg):
+        cmd_np, cmd_bh, shape, dtype = arg
+        cmd_bh += "a = R.randint(1000, size=%s, dtype=%s); " % (shape, dtype)
+        cmd_bh += "res = a == a.flatten()[0]"
+        return cmd_np, cmd_bh
+
+    def test_random_integers(self, arg):
+        cmd_np, cmd_bh, shape, dtype = arg
+        cmd_bh += "a = R.random_integers(1000, size=%s, dtype=%s); " % (shape, dtype)
+        cmd_bh += "res = a == a.flatten()[0]"
+        return cmd_np, cmd_bh
+
+    def test_uniform(self, arg):
+        cmd_np, cmd_bh, shape, dtype = arg
+        cmd_bh += "a = R.uniform(0, 10, size=%s, dtype=%s); " % (shape, dtype)
+        cmd_bh += "res = a == a.flatten()[0]"
+        return cmd_np, cmd_bh
+
+    def test_normal(self, arg):
+        cmd_np, cmd_bh, shape, dtype = arg
+        cmd_bh += "a = R.normal(0, 10, size=%s, dtype=%s); " % (shape, dtype)
+        cmd_bh += "res = a == a.flatten()[0]"
+        return cmd_np, cmd_bh


### PR DESCRIPTION
Using `bh.random.randn` on Python 3 gave

```python
>>> bh.random.randn(10, 10)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "random123.pyx", line 556, in random123.RandomState.randn
  File "random123.pyx", line 691, in random123.RandomState.standard_normal
  File "random123.pyx", line 259, in random123.RandomState.random_sample
  File "random123.pyx", line 213, in random123.RandomState.random123
  File "bhary.pyx", line 95, in bhary.fix_biclass_wrapper.inner
  File "/home/dion/.virtualenvs/veros3/lib/python3.6/site-packages/bohrium/array_manipulation.py", line 372, in reshape
    return numpy.ndarray.reshape(a, newshape, **kwargs)
TypeError: 'float' object cannot be interpreted as an integer
```

the cause being that `/` defaults to float division on Python 3.