### PR TITLE
Fixed #538: Renamed USE_VOLATILE to VOLATILE

### DIFF
--- a/core/jitk/engines/engine_cpu.cpp
+++ b/core/jitk/engines/engine_cpu.cpp
@@ -44,7 +44,7 @@ void EngineCPU::handleExecution(BhIR *bhir) {
             {"strides_as_var", comp.config.defaultGet<bool>("strides_as_var", true)},
             {"index_as_var",   comp.config.defaultGet<bool>("index_as_var", true)},
             {"const_as_var",   comp.config.defaultGet<bool>("const_as_var", true)},
-            {"use_volatile",   comp.config.defaultGet<bool>("use_volatile", false)}
+            {"use_volatile",   comp.config.defaultGet<bool>("volatile", false)}
     };
 
     // Some statistics

--- a/include/jitk/engines/engine_gpu.hpp
+++ b/include/jitk/engines/engine_gpu.hpp
@@ -94,7 +94,7 @@ public:
                 {"strides_as_var", comp.config.defaultGet<bool>("strides_as_var", true)},
                 {"index_as_var",   comp.config.defaultGet<bool>("index_as_var", true)},
                 {"const_as_var",   comp.config.defaultGet<bool>("const_as_var", true)},
-                {"use_volatile",   comp.config.defaultGet<bool>("use_volatile", false)}
+                {"use_volatile",   comp.config.defaultGet<bool>("volatile", false)}
         };
 
         // Some statistics


### PR DESCRIPTION
BH_<backend>_VOLATILE=true to avoid higher precision than NumPy