### PR TITLE
Add missing comma

### DIFF
--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -4,7 +4,7 @@ Welcome!
 ========
 
 Bohrium provides automatic acceleration of array operations in Python/NumPy, C, and C++ targeting multi-core CPUs and GP-GPUs.
-Forget handcrafting CUDA/OpenCL to utilize your GPU and forget threading, mutexes and locks to utilize your multi-core CPU just use Bohrium!
+Forget handcrafting CUDA/OpenCL to utilize your GPU and forget threading, mutexes and locks to utilize your multi-core CPU, just use Bohrium!
 
 Features
 --------


### PR DESCRIPTION
In the index.rst of bohrium is either a comma or a Sentence-separation missing (if my language-feeling is not betraying me completely, which might certainly also be the case). This commit fixes that.