### PR TITLE
Polish user kernel handling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -97,3 +97,6 @@ GTAGS
 GRTAGS
 GPATH
 GSYMS
+
+# VS Code
+.vscode/

--- a/bridge/c/gen_specials.py
+++ b/bridge/c/gen_specials.py
@@ -285,7 +285,7 @@ def main(args):
 
 """ % t
 
-    doc = "\n// Run an user kernel\n"
+    doc = "\n// Run a user kernel\n"
     doc += "// NB: the returned string is invalidated on the next call to bhc_user_kernel()\n"
     impl += doc; head += doc
     decl = "const char* bhc_user_kernel(const char* kernel, int nop, void *operands[], const char *compile_cmd, " \

--- a/bridge/cxx/include/bhxx/Runtime.hpp
+++ b/bridge/cxx/include/bhxx/Runtime.hpp
@@ -171,7 +171,7 @@ public:
     /// Get the number of calls to flush so far
     uint64_t getFlushCount() { return _flush_count; }
 
-    /** Run an user kernel
+    /** Run a user kernel
      *
      * @param kernel The source code of the kernel
      * @param operand_list The operands given to the kernel all of which must be regular arrays

--- a/bridge/npbackend/src/_bh.c
+++ b/bridge/npbackend/src/_bh.c
@@ -901,7 +901,7 @@ static PyMethodDef _bhMethods[] = {
     {"same_view", (PyCFunction) PySameView, METH_VARARGS | METH_KEYWORDS,
             "Return true when `v1` and `v2` is exactly the same (incl. pointing to the same base)\n"},
     {"user_kernel", (PyCFunction) PyUserKernel, METH_VARARGS | METH_KEYWORDS,
-            "Run an user kernel\n"},
+            "Run a user kernel\n"},
     {"is_array_behaving", (PyCFunction) PyIsBehaving, METH_VARARGS | METH_KEYWORDS,
             "Check if a bohrium array is behaving\n"},
     {NULL, NULL, 0, NULL}        /* Sentinel */

--- a/bridge/npbackend/src/handle_special_op.h
+++ b/bridge/npbackend/src/handle_special_op.h
@@ -103,7 +103,7 @@ PyObject* PyGetDeviceContext(PyObject *self, PyObject *args);
  */
 PyObject* PyMessage(PyObject *self, PyObject *args, PyObject *kwds);
 
-/** Run an user kernel
+/** Run a user kernel
 *
 * @param kernel The source code of the kernel
 * @param operand_list The operands given to the kernel all of which must be regular arrays (not scalars)

--- a/bridge/py_api/src/_bh_api.c
+++ b/bridge/py_api/src/_bh_api.c
@@ -190,7 +190,7 @@ static int BhAPI_mem_signal_exist(const void *addr) {
     return bh_mem_signal_exist(addr);
 }
 
-/** Run an user kernel
+/** Run a user kernel
  *
  * @param kernel The source code of the kernel
  * @param nop Number of operands

--- a/doc/source/users/python/index.rst
+++ b/doc/source/users/python/index.rst
@@ -288,7 +288,7 @@ In order to use the OpenCL backend, use the `tag` and `param` of `bh.user_kernel
     # Notice, the OpenCL backend requires global_work_size and local_work_size
     bh.user_kernel.execute(kernel, [a, res],
                            tag="opencl",
-                           param={"global_work_size: 10, 5; local_work_size: 1, 1")
+                           param={"global_work_size": [10, 5], "local_work_size": [1, 1])
     print(res)
 
 .. note:: Remember to use the OpenCL backend by setting `BH_STACK=opencl`.

--- a/doc/source/users/python/index.rst
+++ b/doc/source/users/python/index.rst
@@ -274,6 +274,8 @@ In order to use the OpenCL backend, use the `tag` and `param` of `bh.user_kernel
     import bohrium as bh
 
     kernel = """
+    #pragma OPENCL EXTENSION cl_khr_fp64 : enable
+
     kernel void execute(global double *a, global double *b) {
         int i0 = get_global_id(0);
         int i1 = get_global_id(1);
@@ -286,7 +288,7 @@ In order to use the OpenCL backend, use the `tag` and `param` of `bh.user_kernel
     # Notice, the OpenCL backend requires global_work_size and local_work_size
     bh.user_kernel.execute(kernel, [a, res],
                            tag="opencl",
-                           param="global_work_size: 10, 5; local_work_size: 1, 1")
+                           param={"global_work_size: 10, 5; local_work_size: 1, 1")
     print(res)
 
 .. note:: Remember to use the OpenCL backend by setting `BH_STACK=opencl`.

--- a/include/bh_component.hpp
+++ b/include/bh_component.hpp
@@ -234,7 +234,7 @@ public:
         child.setDeviceContext(device_context);
     }
 
-    /** Run an user kernel
+    /** Run a user kernel
      *
      * @param kernel The source code of the kernel
      * @param operand_list The operands given to the kernel all of which must be regular arrays and not constants


### PR DESCRIPTION
- It felt a bit weird to assemble parameter strings in Python, so `bh.user_kernel.execute` now takes a `dict` as param attribute:

   ```python
   bh.user_kernel.execute(
       kernel,
       [a, res],
       tag="opencl",
       param={"global_work_size": [10, 5], "local_work_size": [1, 1])
   }
   ```

- The OpenCL examples used `double` types, but didn't include the appropriate header
- OpenCL user kernel test is now using 2D arrays