### PR TITLE
Fix travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -43,7 +43,7 @@ jobs:
       env: BH_STACK=openmp BH_OPENMP_MONOLITHIC=1 EXEC="cp27-cp27mu $TEST_SMALL"
 
     # Test of older Python versions
-    - env: BH_STACK=opencl EXEC="cp34-cp34m -m pip install $TEST_DEPS; cp34-cp34m $TEST_ALL"
+    - env: BH_STACK=opencl EXEC="cp34-cp34m -m pip install numpy==1.15; cp34-cp34m $TEST_ALL"
     - env: BH_STACK=opencl EXEC="cp35-cp35m -m pip install $TEST_DEPS; cp35-cp35m $TEST_ALL"
     - env: BH_STACK=opencl EXEC="cp36-cp36m -m pip install $TEST_DEPS; cp36-cp36m $TEST_ALL"
 


### PR DESCRIPTION
NumPy v1.16 segfaults when using Python 2.4 