### PR TITLE
config: added a cache-readonly flag

### DIFF
--- a/config.ini.in
+++ b/config.ini.in
@@ -89,6 +89,9 @@ tmp_dir = NONE
 cache_dir = ${BIN_KERNEL_CACHE_DIR}
 # Maximum number of cache files to keep in the cache dir (use -1 for infinity)
 cache_file_max = 50000
+# Set to true, if no files should we written to the cache. When combining Bohrium and MPI, use this option to avoid
+# write conflicts by only having rank zero write to the cache dir.
+cache_readonly = false
 # Set the size limit of malloc cache in percentage of the unused system memory.
 # NB: if the amount of unused memory cannot be determined, 20% of total memory system is used.
 malloc_cache_limit = 80
@@ -126,6 +129,9 @@ tmp_dir = NONE
 cache_dir = ${BIN_KERNEL_CACHE_DIR}
 # Maximum number of cache files to keep in the cache dir (use -1 for infinity)
 cache_file_max = 50000
+# Set to true, if no files should we written to the cache. When combining Bohrium and MPI, use this option to avoid
+# write conflicts by only having rank zero write to the cache dir.
+cache_readonly = false
 # Set the size limit of malloc cache in percentage of total GPU memory.
 # NB: if the device is a CPU, only 10% of the total memory will be used.
 malloc_cache_limit = 90
@@ -174,6 +180,9 @@ tmp_dir = NONE
 cache_dir = ${BIN_KERNEL_CACHE_DIR}
 # Maximum number of cache files to keep in the cache dir (use -1 for infinity)
 cache_file_max = 50000
+# Set to true, if no files should we written to the cache. When combining Bohrium and MPI, use this option to avoid
+# write conflicts by only having rank zero write to the cache dir.
+cache_readonly = false
 # Set the size limit of malloc cache in percentage of total GPU memory.
 malloc_cache_limit = 90
 # The command to execute the compiler where {OUT} is replaced with the binary file output and {IN} with the source file

--- a/include/bohrium/jitk/engines/engine.hpp
+++ b/include/bohrium/jitk/engines/engine.hpp
@@ -69,6 +69,10 @@ protected:
     // Path to the directory of the cached binary files (e.g. .so files)
     const boost::filesystem::path cache_bin_dir;
 
+    // Set to true, if no files should we written to the cache. When combining Bohrium and MPI,
+    // use this option to avoid write conflicts by only having rank zero write to the cache dir.
+    const bool cache_readonly;
+
     // The hash of the JIT compilation command
     uint64_t compilation_hash{0};
 
@@ -95,6 +99,7 @@ public:
             tmp_src_dir(tmp_dir / "src"),
             tmp_bin_dir(tmp_dir / "obj"),
             cache_bin_dir(comp.config.defaultGet<boost::filesystem::path>("cache_dir", "")),
+            cache_readonly(comp.config.defaultGet<bool>("cache_readonly", false)),
             compilation_hash(0) {
         // Let's make sure that the directories exist
         jitk::create_directories(tmp_src_dir);

--- a/ve/cuda/engine_cuda.cpp
+++ b/ve/cuda/engine_cuda.cpp
@@ -102,9 +102,10 @@ EngineCUDA::EngineCUDA(component::ComponentVE &comp, jitk::Statistics &stat) :
 }
 
 EngineCUDA::~EngineCUDA() {
+    const bool use_cache = not (cache_readonly or cache_bin_dir.empty());
 
     // Move JIT kernels to the cache dir
-    if (not cache_bin_dir.empty()) {
+    if (use_cache) {
         try {
             for (const auto &kernel: _functions) {
                 const fs::path src = tmp_bin_dir / jitk::hash_filename(compilation_hash, kernel.first, ".cubin");
@@ -126,7 +127,7 @@ EngineCUDA::~EngineCUDA() {
         fs::remove_all(tmp_src_dir);
     }
 
-    if (cache_file_max != -1 and not cache_bin_dir.empty()) {
+    if (cache_file_max != -1 and use_cache) {
         util::remove_old_files(cache_bin_dir, cache_file_max);
     }
 

--- a/ve/opencl/engine_opencl.cpp
+++ b/ve/opencl/engine_opencl.cpp
@@ -138,8 +138,10 @@ EngineOpenCL::EngineOpenCL(component::ComponentVE &comp, jitk::Statistics &stat)
 }
 
 EngineOpenCL::~EngineOpenCL() {
+    const bool use_cache = not (cache_readonly or cache_bin_dir.empty());
+
     // Move JIT kernels to the cache dir
-    if (not cache_bin_dir.empty()) {
+    if (use_cache) {
         for (const auto &kernel: _programs) {
             const fs::path dst = cache_bin_dir / jitk::hash_filename(compilation_hash, kernel.first, ".clbin");
             if (not fs::exists(dst)) {
@@ -171,7 +173,7 @@ EngineOpenCL::~EngineOpenCL() {
         fs::remove_all(tmp_src_dir);
     }
 
-    if (cache_file_max != -1 and not cache_bin_dir.empty()) {
+    if (cache_file_max != -1 and use_cache) {
         util::remove_old_files(cache_bin_dir, cache_file_max);
     }
 }

--- a/ve/openmp/engine_openmp.cpp
+++ b/ve/openmp/engine_openmp.cpp
@@ -68,8 +68,10 @@ EngineOpenMP::EngineOpenMP(component::ComponentVE &comp, jitk::Statistics &stat)
 }
 
 EngineOpenMP::~EngineOpenMP() {
+    const bool use_cache = not (cache_readonly or cache_bin_dir.empty());
+
     // Move JIT kernels to the cache dir
-    if (not cache_bin_dir.empty()) {
+    if (use_cache) {
         try {
             for (const auto &kernel: _functions) {
                 const fs::path src = tmp_bin_dir / jitk::hash_filename(compilation_hash, kernel.first, ".so");
@@ -91,7 +93,7 @@ EngineOpenMP::~EngineOpenMP() {
         fs::remove_all(tmp_src_dir);
     }
 
-    if (cache_file_max != -1 and not cache_bin_dir.empty()) {
+    if (cache_file_max != -1 and use_cache) {
         util::remove_old_files(cache_bin_dir, cache_file_max);
     }
 


### PR DESCRIPTION
Set to true, if no files should we written to the cache. When combining Bohrium and MPI,
use this option to avoid write conflicts by only having rank zero write to the cache dir.