### PR TITLE
Proof of concept for a powerful bh107 module

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -100,3 +100,6 @@ GSYMS
 
 # VS Code
 .vscode/
+
+# Python Eggs
+*.egg-info/

--- a/bridge/bh107/bh107/ufuncs.py
+++ b/bridge/bh107/bh107/ufuncs.py
@@ -173,7 +173,7 @@ class Ufunc(object):
     def __str__(self):
         return "<bohrium Ufunc '%s'>" % self.info['name']
 
-    def __call__(self, *operand_list):
+    def __call__(self, *operand_list, **kwargs):
         if len(operand_list) == self.info['nop']:
             out_operand = operand_list[-1]
             in_operands = list(operand_list[:-1])
@@ -216,7 +216,7 @@ class Ufunc(object):
                 assign(tmp_out, out_operand)
         return out_operand
 
-    def reduce(self, ary, axis=0, out=None):
+    def reduce(self, ary, axis=0, out=None, **kwargs):
         """Reduces `ary`'s dimension by len('axis'), by applying ufunc along the
         axes in 'axis'.
 

--- a/test/bh107/conftest.py
+++ b/test/bh107/conftest.py
@@ -1,0 +1,10 @@
+import os
+
+
+def pytest_sessionstart(session):
+    os.environ.update(
+        NUMPY_EXPERIMENTAL_ARRAY_FUNCTION='1',
+        BH_OPENMP_VOLATILE='true',
+        BH_OPENCL_VOLATILE='true',
+        BH_CUDA_VOLATILE='true',
+    )

--- a/test/bh107/numpy_function_test.py
+++ b/test/bh107/numpy_function_test.py
@@ -1,0 +1,85 @@
+import bh107
+import numpy as np
+
+import pytest
+
+UNARY_FUNCS = (
+    'argmin',
+    'argmax',
+    'sort',
+    'argsort',
+    'sin',
+    'cos',
+    'tan',
+    'sinh',
+    'cosh',
+    'tanh',
+    'arcsin',
+    'arccos',
+    'arctan',
+    'arcsinh',
+    'arccosh',
+    'arctanh',
+    'mean',
+    'copy',
+    'ravel'
+)
+
+SHAPES = (
+    (1,),
+    (10,),
+    (10, 10),
+    #(1,) * 100,
+)
+
+DTYPES = (
+    'bool',
+    #'float16',
+    'float32',
+    'float64',
+    'int8',
+    'int16'
+)
+
+NO_BOOL_SUPPORT = (
+    'sin',
+    'cos',
+    'tan',
+    'sinh',
+    'cosh',
+    'tanh',
+    'arcsin',
+    'arccos',
+    'arctan',
+    'arcsinh',
+    'arccosh',
+    'arctanh'
+)
+
+
+
+@pytest.mark.parametrize('dtype', DTYPES)
+@pytest.mark.parametrize('shape', SHAPES)
+@pytest.mark.parametrize('func', UNARY_FUNCS)
+def test_unary_array_func(func, shape, dtype):
+    if func in NO_BOOL_SUPPORT and dtype == 'bool':
+        return
+
+    arr = (100 * bh107.random.rand(*shape)).astype(dtype)
+
+    func_handle = getattr(np, func)
+
+    res_bh107 = func_handle(arr).astype(dtype)
+    if isinstance(res_bh107, bh107.BhArray):
+        res_bh107 = res_bh107.copy2numpy()
+
+    res_np = func_handle(arr.asnumpy()).astype(dtype)
+
+    try:
+        rtol = 10 * np.finfo(arr.dtype).eps
+    except ValueError:
+        rtol = 0
+
+    np.testing.assert_allclose(
+        res_bh107, res_np, rtol=rtol, atol=0
+    )

--- a/test/bh107/ufuncs_test.py
+++ b/test/bh107/ufuncs_test.py
@@ -1,0 +1,118 @@
+import bh107
+import numpy as np
+
+import pytest
+
+UNARY_UFUNCS = (
+    'min',
+    'max',
+    'abs',
+    'sum',
+    'cumsum',
+    'add.reduce',
+    'add.accumulate',
+    'multiply.reduce',
+    'multiply.accumulate',
+    'prod',
+    'cumprod',
+    'logical_not',
+)
+
+BINARY_UFUNCS = (
+    'add',
+    'subtract',
+    'divide',
+    'multiply',
+    'logical_and',
+    'logical_or',
+    'logical_xor',
+    'equal',
+    'not_equal',
+    'less',
+    'less_equal',
+    'greater',
+    'greater_equal',
+)
+
+SHAPES = (
+    (1,),
+    (10,),
+    (10, 10),
+    # (1,) * 100,
+)
+
+DTYPES = (
+    'bool',
+    #'float16',
+    'float32',
+    'float64',
+    'int8',
+    'int16'
+)
+
+
+@pytest.mark.parametrize('dtype', DTYPES)
+@pytest.mark.parametrize('shape', SHAPES)
+@pytest.mark.parametrize('ufunc', UNARY_UFUNCS)
+def test_unary_array_ufunc(ufunc, shape, dtype):
+    if 'logical' in ufunc and dtype != 'bool':
+        return
+
+    arr = (100 * bh107.random.rand(*shape)).astype(dtype)
+    if '.' in ufunc:
+        ufunc, method = ufunc.split('.')
+    else:
+        method = '__call__'
+
+    func_handle = getattr(getattr(np, ufunc), method)
+
+    res_bh107 = func_handle(arr).astype(dtype)
+    if isinstance(res_bh107, bh107.BhArray):
+        res_bh107 = res_bh107.copy2numpy()
+
+    res_np = func_handle(arr.asnumpy()).astype(dtype)
+
+    try:
+        rtol = 10 * np.finfo(arr.dtype).eps
+    except ValueError:
+        rtol = 0
+
+    np.testing.assert_allclose(
+        res_bh107, res_np, rtol=rtol, atol=0
+    )
+
+
+@pytest.mark.parametrize('dtype', DTYPES)
+@pytest.mark.parametrize('shape', SHAPES)
+@pytest.mark.parametrize('ufunc', BINARY_UFUNCS)
+def test_binary_array_ufunc(ufunc, shape, dtype):
+    if 'logical' in ufunc and dtype != 'bool':
+        return
+
+    if ufunc in ('subtract',) and dtype == 'bool':
+        return
+
+    arr1 = (100 * bh107.random.rand(*shape)).astype(dtype)
+    arr2 = arr1.copy()
+
+    if '.' in ufunc:
+        ufunc, method = ufunc.split('.')
+    else:
+        method = '__call__'
+
+    func_handle = getattr(getattr(np, ufunc), method)
+
+    res_bh107 = func_handle(arr1, arr2).astype(dtype)
+    if isinstance(res_bh107, bh107.BhArray):
+        res_bh107 = res_bh107.copy2numpy()
+
+    res_np = func_handle(arr1.asnumpy(), arr2.asnumpy()).astype(dtype)
+
+    try:
+        rtol = 10 * np.finfo(arr1.dtype).eps
+    except ValueError:
+        rtol = 0
+
+    np.testing.assert_allclose(
+        res_bh107, res_np, rtol=rtol, atol=0
+    )


### PR DESCRIPTION
The idea is that there should be 2 modes of using `bh107`:

#### 1. Implicitly through NumPy
(via `__array_function__`, `__array_ufunc__`, `__array_interface__`, requires recent NumPy)

Example usage:

```python
import numpy as np

a = bh107.random.rand(10, 10)
np_array = np.random.rand(10, 10)

np.mean(a)  # returns bh107 array, computed via bohrium

np.maximum(a, np_array)  # returns bh107 array, np_array is cast to BhArray before computation

np.fft.fft(a)  # not implemented in bh107, computed via NumPy, returns bh107 array

bh107.BhArray.from_numpy(np.fft.fft(a.asnumpy()))  # what is done under the hood

np.add.reduce(a, at=mask)  # fancy argument we don't support, pass through NumPy, returns bh107 array

plt.imshow(a)  # works, because matplotlib casts its inputs via np.array()

some_other_library.my_fancy_function(a)  # probably raises an exception, users should use a.asnumpy()
```

The behavior of some of the more problematic implicit conversions could be controlled by an environment variable:

```python
>>> import os
>>> os.environ['BH107_NUMPY_CONVERSION'] = 'warn'  # default

>>> np.array(bh_array)  # should be using bh_array.asnumpy or bh_array.copy2numpy
ImplicitConversionWarning: Copying bh107 array to NumPy

>>> plt.imshow(bh_array)  # warns on implicit conversion via np.array()
ImplicitConversionWarning: Copying bh107 array to NumPy

>>> np.fft.fft(a)
ImplicitConversionWarning: Copying bh107 array to NumPy

>>> np.add.reduce(a, at=mask)
ImplicitConversionWarning: Copying bh107 array to NumPy
```

Other possible values for `BH107_NUMPY_CONVERSION` would then be `ignore` and `raise`.

#### 2. Explicitly

Guaranteed to have no NumPy interactions, but is restricted to the functions we implement.

Examples:

```python
>>> import bh107

>>> a = bh107.random.rand(10, 10)

>>> bh.mean(a)   # good
>>> a.mean()  # equivalent
>>> bh.maximum(a, np_array)  # good

>>> bh.fft.fttn(a)  # oops
AttributeError: module 'bh107' has no attribute 'fft'
```

(best used with `BH107_NUMPY_CONVERSION=raise`).

---

### What is the gain compared to `bohrium`?

- `bh107.BhArray` does not subclass `np.ndarray`, so it cannot be passed to C APIs without explicit conversion to NumPy, so no more corruption (fingers crossed)
- Give control back to the user
- We are explicit about what is supported and what isn't: `dir(bh107)`
- Explicit feature support lets us meaningfully measure coverage and build a well-tested library
- Barely losing any flexibility

--- 

Happy for any comments / API suggestions.